### PR TITLE
add description to hemera core package.json

### DIFF
--- a/packages/hemera/package.json
+++ b/packages/hemera/package.json
@@ -4,6 +4,7 @@
   "version": "0.4.17",
   "main": "build/index.js",
   "homepage": "https://hemerajs.github.io/hemera/",
+  "description": "The core package of hemera",
   "repository": {
     "url": "git@github.com:hemerajs/hemera.git",
     "type": "git"


### PR DESCRIPTION
this info is exposed on yarnpkg.com, npmjs.com and others. If it's not filled in, the first part of the readme is used (the badges). 

This info should be added to the other packages too.