### PR TITLE
Reverse the scopes subset calculation

### DIFF
--- a/packages/hemera-jwt-auth/index.js
+++ b/packages/hemera-jwt-auth/index.js
@@ -54,7 +54,7 @@ exports.plugin = Hp(function hemeraJwtAuth (options) {
           auth.scope = [auth.scope]
         }
         // check if scope is subset
-        if (isSubset(auth.scope, decoded.scope)) {
+        if (isSubset(decoded.scope, auth.scope)) {
           return next()
         }
         // invalid scope return error


### PR DESCRIPTION
Where two scopes are present in the callers token ('math', 'other'), and the action only requires one scope (e.g. 'math'), the check fails in the isSubset function, as I think it's testing the subset the wrong way around.