### PR TITLE
Added custom error constructor support for createError functionality.

### DIFF
--- a/docs/4_api.html
+++ b/docs/4_api.html
@@ -173,7 +173,7 @@
                     <p>Returns the current node-nats instance.</p>
                     <h4 class="section-header">ready(handler: Function)</h4>
                     <p>Ready event.</p>
-                    <h4 class="section-header"><i class="accessor">static</i> createError(name: String)</h4>
+                    <h4 class="section-header"><i class="accessor">static</i> createError(name: String, customConstructor: Function)</h4>
                     <p>Create a custom error object.</p>
                     <h4 class="section-header">act(pattern: Object, handler: Function)</h4>
                     <p>Call a service method.</p>

--- a/examples/basic/custom-errors.js
+++ b/examples/basic/custom-errors.js
@@ -5,14 +5,32 @@ const nats = require('nats').connect()
 
 const hemera = new Hemera(nats)
 
+const ERROR_CODES = {
+  1: 'Invalid foo',
+  2: 'Invalid bar',
+  3: 'Invalid baz'
+};
+
 hemera.ready(() => {
   const UnauthorizedError = Hemera.createError('Unauthorized')
+  const ForbiddenError = Hemera.createError('Forbidden', function(code){
+    this.code = code;
+    this.message = ERROR_CODES[code];
+  })
 
   hemera.add({
     topic: 'math',
     cmd: 'add'
   }, function (req, cb) {
     const err = new UnauthorizedError('Unauthorized action')
+    cb(err)
+  })
+
+  hemera.add({
+    topic: 'math',
+    cmd: 'minus'
+  }, function (req, cb) {
+    const err = new ForbiddenError(3)
     cb(err)
   })
 
@@ -23,5 +41,14 @@ hemera.ready(() => {
     b: 2
   }, function (err, resp) {
     console.log(err instanceof UnauthorizedError)
+  })
+
+  hemera.act({
+    topic: 'math',
+    cmd: 'minus',
+    a: 1,
+    b: 2
+  }, function (err, resp) {
+    console.log(err instanceof ForbiddenError)
   })
 })

--- a/packages/hemera/lib/index.d.ts
+++ b/packages/hemera/lib/index.d.ts
@@ -36,7 +36,7 @@ declare class Hemera extends events.EventEmitter {
   act(pattern: string | Pattern, callback: Function): void;
   add(pattern: string | Pattern, callback: Function): AddMeta;
   use(params: PluginDefinition, options?: any): void;
-  createError(name: string): any;
+  createError(name: string, customConstructor: function): any;
   decorate(prop: string, value: any): void;
   remove(topic: string, maxMessages: number): boolean;
   list(Pattern, options: any): any;

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -435,8 +435,8 @@ class Hemera extends EventEmitter {
    *
    * @memberOf Hemera
    */
-  static createError (name) {
-    return SuperError.subclass(name)
+  static createError (name, customConstructor) {
+    return SuperError.subclass(name, customConstructor)
   }
 
   /**
@@ -467,12 +467,13 @@ class Hemera extends EventEmitter {
    * Create a custom super error object in a running hemera instance
    *
    * @param {any} name
+   * @param {function} customConstructor
    * @returns
    *
    * @memberOf Hemera
    */
-  createError (name) {
-    return SuperError.subclass(name)
+  createError (name, customConstructor) {
+    return SuperError.subclass(name, customConstructor)
   }
 
   /**


### PR DESCRIPTION
Added support for this feature of [super-error](https://github.com/busbud/super-error#custom-constructors) because I found important have a way to get custom error derived from you expected class with custom constructor logic like for example base on error code retrieve on constructor get an I18N message.