### PR TITLE
Prettier globs should be surrounded by double-quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "precommit": "npm run format",
     "lint": "eslint --fix ./packages/**/*.js ./test/**/*.js",
-    "format": "prettier ./packages/**/*.js ./examples/**/*.js ./test/**/*.js --write && npm run lint",
+    "format": "prettier \"./packages/**/*.js\" \"./examples/**/*.js\" \"./test/**/*.js\" --write && npm run lint",
     "setup": "npm i && lerna bootstrap",
     "ci:setup": "npm i && lerna bootstrap --npm-client=npm",
     "clean": "lerna clean",


### PR DESCRIPTION
Prettier globs should be surrounded by double-quotes per 
https://github.com/prettier/prettier/blob/master/README.md#cli