### PR TITLE
Attach hops in extension errors

### DIFF
--- a/examples/basic/payload-validation.js
+++ b/examples/basic/payload-validation.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const Hemera = require('./../../packages/hemera')
+const nats = require('nats').connect()
+const HemeraJoi = require('./../../packages/hemera-joi')
+
+const hemera = new Hemera(nats, {
+  logLevel: 'error',
+  prettyLog: false
+})
+
+hemera.use(HemeraJoi)
+
+hemera.ready(() => {
+  hemera.setOption('payloadValidator', 'hemera-joi')
+
+  let Joi = hemera.joi
+
+  hemera.add(
+    {
+      topic: 'math',
+      cmd: 'add',
+      a: Joi.number().required(),
+      b: Joi.number().required()
+    },
+    (req, cb) => {
+      cb(null, req.a + req.b)
+    }
+  )
+
+  hemera.act(
+    {
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 'a'
+    },
+    function(err, resp) {
+      this.log.error(err)
+    }
+  )
+})

--- a/examples/basic/payload-validation.js
+++ b/examples/basic/payload-validation.js
@@ -5,8 +5,7 @@ const nats = require('nats').connect()
 const HemeraJoi = require('./../../packages/hemera-joi')
 
 const hemera = new Hemera(nats, {
-  logLevel: 'error',
-  prettyLog: false
+  logLevel: 'error'
 })
 
 hemera.use(HemeraJoi)

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -603,7 +603,7 @@ class Hemera extends EventEmitter {
     const self = this
     // check if any error was set before
     if (extensionError) {
-      self._reply.error = extensionError
+      self._reply.error = self._attachHops(extensionError)
       const internalError = new Errors.HemeraError(
         Constants.EXTENSION_ERROR,
         self.errorDetails
@@ -684,17 +684,14 @@ class Hemera extends EventEmitter {
 
     return m.value
   }
-
   /**
    *
    *
    * @param {any} err
-   * @param {any} resp
    * @returns
-   *
    * @memberof Hemera
    */
-  _actionHandler(err, resp) {
+  _attachHops(err) {
     const self = this
 
     if (err) {
@@ -711,8 +708,26 @@ class Hemera extends EventEmitter {
       } else {
         err.hops = [errorDetails]
       }
+    }
 
+    return err
+  }
+
+  /**
+   *
+   *
+   * @param {any} err
+   * @param {any} resp
+   * @returns
+   *
+   * @memberof Hemera
+   */
+  _actionHandler(err, resp) {
+    const self = this
+
+    if (err) {
       self._reply.error = self.getRootError(err)
+      self._reply.error = self._attachHops(self._reply.error)
 
       self.finish()
       return
@@ -801,7 +816,7 @@ class Hemera extends EventEmitter {
 
     // check if any error was set before
     if (extensionError) {
-      self._reply.error = extensionError
+      self._reply.error = self._attachHops(extensionError)
       self.emit('serverResponseError', extensionError)
       self.finish()
       return
@@ -840,7 +855,7 @@ class Hemera extends EventEmitter {
 
     // check if any error was set before
     if (extensionError) {
-      self._reply.error = extensionError
+      self._reply.error = self._attachHops(extensionError)
 
       const internalError = new Errors.HemeraError(
         Constants.EXTENSION_ERROR,

--- a/test/hemera/server-extension-errors.spec.js
+++ b/test/hemera/server-extension-errors.spec.js
@@ -59,6 +59,10 @@ describe('Server Extension error', function() {
           expect(err).to.be.exists()
           expect(err.name).to.be.equals('Unauthorized')
           expect(err.message).to.be.equals('test')
+          expect(err.hops).to.be.exists()
+          expect(err.hops.length).to.be.equals(1)
+          expect(err.hops[0].service).to.be.equals('math')
+          expect(err.hops[0].method).to.be.equals('a:1,b:2,cmd:add,topic:math')
           hemera.close(done)
         }
       )
@@ -107,6 +111,10 @@ describe('Server Extension error', function() {
           expect(err).to.be.exists()
           expect(err.name).to.be.equals('Error')
           expect(err.message).to.be.equals('test')
+          expect(err.hops).to.be.exists()
+          expect(err.hops.length).to.be.equals(1)
+          expect(err.hops[0].service).to.be.equals('math')
+          expect(err.hops[0].method).to.be.equals('a:1,b:2,cmd:add,topic:math')
           hemera.close(done)
         }
       )
@@ -157,6 +165,10 @@ describe('Server Extension error', function() {
           expect(err).to.be.exists()
           expect(err.name).to.be.equals('Unauthorized')
           expect(err.message).to.be.equals('test')
+          expect(err.hops).to.be.exists()
+          expect(err.hops.length).to.be.equals(1)
+          expect(err.hops[0].service).to.be.equals('math')
+          expect(err.hops[0].method).to.be.equals('a:1,b:2,cmd:add,topic:math')
           hemera.close(done)
         }
       )
@@ -205,6 +217,10 @@ describe('Server Extension error', function() {
           expect(err).to.be.exists()
           expect(err.name).to.be.equals('Error')
           expect(err.message).to.be.equals('test')
+          expect(err.hops).to.be.exists()
+          expect(err.hops.length).to.be.equals(1)
+          expect(err.hops[0].service).to.be.equals('math')
+          expect(err.hops[0].method).to.be.equals('a:1,b:2,cmd:add,topic:math')
           hemera.close(done)
         }
       )

--- a/test/hemera/server-extension-errors.spec.js
+++ b/test/hemera/server-extension-errors.spec.js
@@ -121,6 +121,58 @@ describe('Server Extension error', function() {
     })
   })
 
+  it('Should be able to pass an error to onServerPreHandler', function(done) {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    let plugin = function(hemera, options, done) {
+      hemera.ext('onServerPreHandler', function(ctx, req, res, next) {
+        next(new Error('test'))
+      })
+
+      hemera.add(
+        {
+          cmd: 'add',
+          topic: 'math'
+        },
+        (resp, cb) => {
+          cb(null, resp.a + resp.b)
+        }
+      )
+
+      done()
+    }
+
+    hemera.use({
+      plugin: plugin,
+      options: {
+        name: 'myPlugin'
+      }
+    })
+
+    hemera.ready(() => {
+      hemera.act(
+        {
+          topic: 'math',
+          cmd: 'add',
+          a: 1,
+          b: 2
+        },
+        (err, resp) => {
+          expect(err).to.be.exists()
+          expect(err.name).to.be.equals('Error')
+          expect(err.message).to.be.equals('test')
+          expect(err.hops).to.be.exists()
+          expect(err.hops.length).to.be.equals(1)
+          expect(err.hops[0].service).to.be.equals('math')
+          expect(err.hops[0].method).to.be.equals('a:1,b:2,cmd:add,topic:math')
+          hemera.close(done)
+        }
+      )
+    })
+  })
+
   it('Should be able to pass a custom super error to onServerPreResponse', function(
     done
   ) {


### PR DESCRIPTION
This PR enables that hops are attached to extensions errors. This is very useful to know where the error comes from.