### PR TITLE
Added count() to hemera-store

### DIFF
--- a/packages/hemera-mongo-store/README.md
+++ b/packages/hemera-mongo-store/README.md
@@ -178,6 +178,7 @@ Fine-tuning of the calls to the MongoDB Node.js driver can be performed via `opt
 * [replace](https://github.com/hemerajs/hemera/tree/master/packages/hemera-store#replace) => [updateMany](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#updateMany)
 * [replaceById](https://github.com/hemerajs/hemera/tree/master/packages/hemera-store#replacebyid) => [findOneAndReplace](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#findOneAndReplace)
 * [exists](https://github.com/hemerajs/hemera/tree/master/packages/hemera-store#exists): NA
+* [count](https://github.com/hemerajs/hemera/tree/master/packages/hemera-store#count) => [count](http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#count)
 
 ### Example:
 

--- a/packages/hemera-mongo-store/index.js
+++ b/packages/hemera-mongo-store/index.js
@@ -26,7 +26,8 @@ exports.options = {
     remove: {},
     removeById: {},
     replace: { upsert: true },
-    replaceById: {}
+    replaceById: {},
+    count: {}
   }
 }
 
@@ -182,6 +183,21 @@ function hemeraMongoStore(hemera, opts, done) {
       req.query = deserialize(req.query)
 
       store.find(req, req.options, (err, result) => {
+        if (err) {
+          cb(err)
+        } else {
+          cb(null, preResponseHandler(result))
+        }
+      })
+    })
+
+    hemera.add({ topic: 'mongo-store', cmd: 'count' }, function(req, cb) {
+      const collection = db.collection(req.collection)
+      const store = new MongoStore(collection, opts)
+      store.ObjectID = ObjectID
+      req.query = deserialize(req.query)
+
+      store.count(req, req.options, (err, result) => {
         if (err) {
           cb(err)
         } else {

--- a/packages/hemera-mongo-store/index.js
+++ b/packages/hemera-mongo-store/index.js
@@ -191,7 +191,7 @@ function hemeraMongoStore(hemera, opts, done) {
       })
     })
 
-    hemera.add({ topic: 'mongo-store', cmd: 'count' }, function(req, cb) {
+    hemera.add(StorePattern.count(topic), function(req, cb) {
       const collection = db.collection(req.collection)
       const store = new MongoStore(collection, opts)
       store.ObjectID = ObjectID

--- a/packages/hemera-mongo-store/store.js
+++ b/packages/hemera-mongo-store/store.js
@@ -268,6 +268,21 @@ class MongoStore extends Store {
       }
     )
   }
+  /**
+   */
+  count(req, options, cb) {
+    this._driver.count(
+      req.query,
+      this.options.store.count,
+      function(err, resp) {
+        if (err) {
+          return cb(err)
+        }
+        const result = resp
+        cb(err, result)
+      }
+    )
+  }
 }
 
 module.exports = MongoStore

--- a/packages/hemera-mongo-store/test/ejson.spec.js
+++ b/packages/hemera-mongo-store/test/ejson.spec.js
@@ -398,4 +398,22 @@ describe('Hemera-mongo-store with EJSON', function() {
       }
     )
   })
+
+  it('count', function(done) {
+    hemera.act(
+      {
+        topic,
+        cmd: 'count',
+        collection: testCollection,
+        query: EJSON.serialize({ name: new RegExp(/^nad/, 'i') })
+        //query: { },
+      },
+      function(err, resp) {
+        expect(err).to.be.not.exists()
+        expect(resp).to.be.a.number()
+        expect(resp).to.be.equal(2)
+        done()
+      }
+    )
+  })
 })

--- a/packages/hemera-mongo-store/test/index.spec.js
+++ b/packages/hemera-mongo-store/test/index.spec.js
@@ -400,4 +400,21 @@ describe('Hemera-mongo-store', function() {
       }
     )
   })
+
+  it('count', function(done) {
+    hemera.act(
+      {
+        topic,
+        cmd: 'count',
+        collection: testCollection,
+        query: { }
+      },
+      function(err, resp) {
+        expect(err).to.be.not.exists()
+        expect(resp).to.be.a.number()
+        expect(resp).to.equal(10)
+        done()
+      }
+    )
+  })
 })

--- a/packages/hemera-store/README.md
+++ b/packages/hemera-store/README.md
@@ -18,6 +18,7 @@ Simple API to be interoperable with most database interfaces.
   * [replace](#replace)
   * [replaceById](#replacebyid)
   * [exists](#exists)
+  * [count](#count)
 
 Provide a unique pattern set for all common api methods. We had to choose for some conventions across document and table oriented stores.
 
@@ -249,3 +250,24 @@ hemera.act({
   query: {}
 }, function(err, resp) ...)
 ```
+
+-------------------------------------------------------
+### count
+
+The pattern is:
+
+* `topic`: is the store name to publish to `<name>-store`
+* `cmd`: is the command to execute `count`
+* `collection`: the name of the table or collection `string`
+* `query`: the search criteria `object`
+
+Example:
+```js
+hemera.act({
+  topic: 'sql-store',
+  cmd: 'count',
+  collection: 'product',
+  query: {}
+}, function(err, resp) ...)
+```
+

--- a/packages/hemera-store/pattern.js
+++ b/packages/hemera-store/pattern.js
@@ -211,6 +211,24 @@ class StorePattern {
       query: Joi.object().required()
     }
   }
+
+  /**
+   *
+   *
+   * @static
+   * @param {any} topic
+   * @returns
+   *
+   * @memberOf StorePattern
+   */
+  static count(topic) {
+    return {
+      topic,
+      cmd: 'count',
+      collection: Joi.string().required(),
+      query: Joi.object().required(),
+    }
+  }
 }
 
 module.exports = StorePattern

--- a/packages/hemera-store/pattern.js
+++ b/packages/hemera-store/pattern.js
@@ -226,7 +226,7 @@ class StorePattern {
       topic,
       cmd: 'count',
       collection: Joi.string().required(),
-      query: Joi.object().required(),
+      query: Joi.object().required()
     }
   }
 }


### PR DESCRIPTION
Hi,

I need to implement `count()` for `hemera-mongo-store`

Question: Should I also add the new pattern `count` to `hemera-store`? Or keep it specific to `hemera-mongo-store` as it's not implemented for many of the others Store back-ends?

PS: thist first commit is a proof of concept only (no doc, no test)