### PR TITLE
add expectedMessages$ flag

### DIFF
--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -321,6 +321,27 @@ hemera.act({
 })
 </code>
                     </pre>
+                    <h4 class="section-h4">Expect N messages</h4>
+                    <p>This ensure that you have to receive N messages before a timeout error is thrown and the request is canceled. You can combine it with the <code>maxMessages$</code> flag to require a minimum count of messages within the request-timeout.</p>
+          <pre>
+<code class="language-javascript">
+hemera.add({
+  topic: "math",
+  cmd: "add"
+}, function(req) {
+  this.reply(req.a + req.b)
+})
+
+hemera.act({
+    topic: "math",
+    cmd: "add",
+    a: 1, b: 1,
+    expectedMessages$: 10
+}, function(err, resp) {
+  // Can receive 10 messages
+})
+</code>
+                              </pre>
           <h4 class="section-h4">Reply</h4>
           <p>You can reply any value even primitive values like
             <code>true, 1, 5.0</code>. The first argument expect an error object.</p>

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -273,8 +273,8 @@
             or first to respond. In a one-to-many exchange, you set a limit on the number of responses the requestor may
             receive. In a request-response exchange, publish request operation publishes a message with a reply subject expecting
             a response on that reply subject. You can request to automatically wait for a response inline. The request creates
-            an INBOX-channel and performs a request call with the inbox reply and returns the first reply received. This is optimized
-            in the case of multiple responses.
+            an INBOX-channel and performs a request call with the inbox reply and returns the first reply received. This
+            is optimized in the case of multiple responses.
           </p>
           <br>
           <h4 class="section-header">NATS Queueing</h4>
@@ -289,10 +289,11 @@
             <code>queue$: name</code> as property to the add pattern. Any subscriber with a different queue on this topic will receive a message.
             You can only have one different queue name per Hemera instance.</div>
           <div class="alert alert-warning" role="alert">
-            <i class="fa fa-warning" aria-hidden="true"></i> It's very important to notice that you have to cancel the request INBOX-channel by yourself <code>this.remove(this.sid)</code> if you want to cancel
-            it before all expected number of messages are reached, the maximum messages are proceed or the timeout is reached.
+            <i class="fa fa-warning" aria-hidden="true"></i> It's very important to notice that you have to cancel the request INBOX-channel by yourself
+            <code>this.remove(this.sid)</code> if you want to cancel it before all expected number of messages are reached, the maximum messages are proceed
+            or the timeout is reached.
           </div>
-          <h4 class="section-h4">Request (point-to-point) by default</h4>
+          <h4 class="section-h4">Request (point-to-point)</h4>
           <p>This is the default method to start a request. The INBOX-channel is automatically closed after the response.</p>
           <pre>
 <code class="language-javascript">
@@ -305,7 +306,8 @@ hemera.act({
 })
 </code></pre>
           <h4 class="section-h4">Receive multiple messages</h4>
-          <p>This allows to receive multiple messages (in this case 10). If you don't receive 10 messages the INBOX channel is still open and you have to close it manually.</p>
+          <p>This allows to receive multiple messages (in this case 10). If you don't receive 10 messages the INBOX channel
+            is still open and you have to close it manually.</p>
           <pre>
 <code class="language-javascript">
 hemera.add({
@@ -330,7 +332,9 @@ hemera.act({
 </code>
 </pre>
           <h4 class="section-h4">Receive at least N messages</h4>
-          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout before a timeout error is thrown and the INBOX-channel is unsubscribed. You can't receive more than expected messages the INBOX-channel is closed automatically.</p>
+          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout (default 2000) before
+            a timeout error is thrown and the INBOX-channel is unsubscribed. You can't receive more than expected messages
+            the INBOX-channel is closed automatically.</p>
           <pre>
 <code class="language-javascript">
 hemera.add({
@@ -351,6 +355,29 @@ hemera.act({
 })
 </code>
                               </pre>
+          <h4 class="section-h4">Receive unknown count of messages</h4>
+          <p>This allows you to receive an unknown count of messages but be aware that you are responsible to close the INBOX-channel.</p>
+          <pre>
+                    <code class="language-javascript">
+hemera.add({
+  topic: "math",
+  cmd: "add"
+}, function(req) {
+  this.reply(req.a + req.b)
+})
+
+hemera.act({
+    topic: "math",
+    cmd: "add",
+    a: 1,
+    b: 1,
+    maxMessages$: -1
+}, function(err, resp) {
+  // you have to close it
+  this.remove(this.sid)
+})
+</code>
+</pre>
           <h4 class="section-h4">Reply</h4>
           <p>You can reply any value even primitive values like
             <code>true, 1, 5.0</code>. The first argument expect an error object.</p>
@@ -365,8 +392,8 @@ hemera.add({
 </code>
                     </pre>
           <h4 class="section-h4">Auto-unsubscribe</h4>
-          <p>The INBOX-channel of your request-reply action is automatically closed when the expected number of messages is reached,
-            the maximum messages are proceed or the timeout is reached.</p>
+          <p>The INBOX-channel of your request-reply action is automatically closed when the expected number of messages is
+            reached, the maximum messages are proceed or the timeout is reached.</p>
           <pre>
           <code class="language-javascript">
 hemera.add({

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -273,7 +273,7 @@
             or first to respond. In a one-to-many exchange, you set a limit on the number of responses the requestor may
             receive. In a request-response exchange, publish request operation publishes a message with a reply subject expecting
             a response on that reply subject. You can request to automatically wait for a response inline. The request creates
-            an inbox and performs a request call with the inbox reply and returns the first reply received. This is optimized
+            an INBOX-channel and performs a request call with the inbox reply and returns the first reply received. This is optimized
             in the case of multiple responses.
           </p>
           <br>
@@ -289,11 +289,11 @@
             <code>queue$: name</code> as property to the add pattern. Any subscriber with a different queue on this topic will receive a message.
             You can only have one different queue name per Hemera instance.</div>
           <div class="alert alert-warning" role="alert">
-            <i class="fa fa-warning" aria-hidden="true"></i> It's very important to notice that you have to cancel the request INBOX by yourself <code>this.remove(this.sid)</code> if you want to cancel
+            <i class="fa fa-warning" aria-hidden="true"></i> It's very important to notice that you have to cancel the request INBOX-channel by yourself <code>this.remove(this.sid)</code> if you want to cancel
             it before all expected number of messages are reached, the maximum messages are proceed or the timeout is reached.
           </div>
           <h4 class="section-h4">Request (point-to-point) by default</h4>
-          <p>This is the default method to start a request. The INBOX channel is automatically closed after the response.</p>
+          <p>This is the default method to start a request. The INBOX-channel channel is automatically closed after the response.</p>
           <pre>
 <code class="language-javascript">
 hemera.act({
@@ -327,7 +327,7 @@ hemera.act({
 </code>
 </pre>
           <h4 class="section-h4">Receive at least N messages</h4>
-          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout before a timeout error is thrown and the INBOX channel is unsubscribed.</p>
+          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout before a timeout error is thrown and the INBOX-channel is unsubscribed.</p>
           <pre>
 <code class="language-javascript">
 hemera.add({
@@ -362,7 +362,7 @@ hemera.add({
 </code>
                     </pre>
           <h4 class="section-h4">Auto-unsubscribe</h4>
-          <p>The INBOX of your request-reply action is automatically closed when the expected number of messages is reached,
+          <p>The INBOX-channel of your request-reply action is automatically closed when the expected number of messages is reached,
             the maximum messages are proceed or the timeout is reached.</p>
           <pre>
           <code class="language-javascript">

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -323,6 +323,9 @@ hemera.act({
     maxMessages$: 10
 }, function(err, resp) {
   // You can receive 10 messages but also need 10 responses
+
+  // if you receive only 5 you have to close it
+  this.remove(this.sid)
 })
 </code>
 </pre>

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -293,7 +293,7 @@
             it before all expected number of messages are reached, the maximum messages are proceed or the timeout is reached.
           </div>
           <h4 class="section-h4">Request (point-to-point) by default</h4>
-          <p>This is the default method to start a request. The INBOX-channel channel is automatically closed after the response.</p>
+          <p>This is the default method to start a request. The INBOX-channel is automatically closed after the response.</p>
           <pre>
 <code class="language-javascript">
 hemera.act({

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -288,7 +288,12 @@
             <i class="fa fa-info" aria-hidden="true"></i> You can define a different queue if you pass the
             <code>queue$: name</code> as property to the add pattern. Any subscriber with a different queue on this topic will receive a message.
             You can only have one different queue name per Hemera instance.</div>
+          <div class="alert alert-warning" role="alert">
+            <i class="fa fa-warning" aria-hidden="true"></i> It's very important to notice that you have to cancel the request INBOX by yourself <code>this.remove(this.sid)</code> if you want to cancel
+            it before all expected number of messages are reached, the maximum messages are proceed or the timeout is reached.
+          </div>
           <h4 class="section-h4">Request (point-to-point) by default</h4>
+          <p>This is the default method to start a request. The INBOX channel is automatically closed after the response.</p>
           <pre>
 <code class="language-javascript">
 hemera.act({
@@ -300,8 +305,7 @@ hemera.act({
 })
 </code></pre>
           <h4 class="section-h4">Receive multiple messages</h4>
-          <p>This means that the subscriber has the chance to respond multiple messages (in this case 10) even when first response
-            was an issue. You have to change the <code>maxMessages$</code> to a specific number or <code>-1</code> for no limit. Don't call the callback twice use the <code>this.reply([Error, any])</code> method.</p>
+          <p>This allows to receive multiple messages (in this case 10). If you don't receive 10 messages the INBOX channel is still open and you have to close it manually.</p>
           <pre>
 <code class="language-javascript">
 hemera.add({
@@ -314,15 +318,16 @@ hemera.add({
 hemera.act({
     topic: "math",
     cmd: "add",
-    a: 1, b: 1,
+    a: 1,
+    b: 1,
     maxMessages$: 10
 }, function(err, resp) {
-  // Can receive 10 messages
+  // You can receive 10 messages but also need 10 responses
 })
 </code>
-                    </pre>
-                    <h4 class="section-h4">Expect N messages</h4>
-                    <p>This ensure that you have to receive N messages before a timeout error is thrown and the request is canceled. You can combine it with the <code>maxMessages$</code> flag to require a minimum count of messages within the request-timeout.</p>
+</pre>
+          <h4 class="section-h4">Receive at least N messages</h4>
+          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout before a timeout error is thrown and the INBOX channel is unsubscribed.</p>
           <pre>
 <code class="language-javascript">
 hemera.add({
@@ -335,10 +340,11 @@ hemera.add({
 hemera.act({
     topic: "math",
     cmd: "add",
-    a: 1, b: 1,
-    expectedMessages$: 10
+    a: 1,
+    b: 1,
+    expectedMessages$: 5
 }, function(err, resp) {
-  // Can receive 10 messages
+  // You have to receive 5 responses
 })
 </code>
                               </pre>
@@ -355,20 +361,22 @@ hemera.add({
 })
 </code>
                     </pre>
-          <h4 class="section-h4">Auto-unsubscribe after
-            <code>maxMessages$</code> messages received</h4>
-          <p>As soon as the subscriber proceed (in this case the first message) the subscriber will be unsubscribed from NATS.</p>
+          <h4 class="section-h4">Auto-unsubscribe</h4>
+          <p>The INBOX of your request-reply action is automatically closed when the expected number of messages is reached,
+            the maximum messages are proceed or the timeout is reached.</p>
           <pre>
-<code class="language-javascript">
+          <code class="language-javascript">
 hemera.add({
   topic: "math",
   cmd: "add",
-  maxMessages$: 1
+  maxMessages$: 10,
+  expectedMessages$: 5,
+  timeout$: 2000
 }, function (req, cb) {
   cb(null, req.a + req.b)
 })
-</code>
-                    </pre>
+          </code>
+                              </pre>
           <h4 class="section-h4">Async / Await</h4>
           <p>You can also pass an async function.</p>
           <pre>

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -330,7 +330,7 @@ hemera.act({
 </code>
 </pre>
           <h4 class="section-h4">Receive at least N messages</h4>
-          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout before a timeout error is thrown and the INBOX-channel is unsubscribed.</p>
+          <p>This ensures that you have to receive at least N responses (in this case 5) within the timeout before a timeout error is thrown and the INBOX-channel is unsubscribed. You can't receive more than expected messages the INBOX-channel is closed automatically.</p>
           <pre>
 <code class="language-javascript">
 hemera.add({

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint-staged": "^6.1.1",
     "mocha": "^5.0.1",
     "mocha-lcov-reporter": "^1.3.0",
-    "nats": "^0.7.29",
+    "nats": "^0.8.2",
     "nyc": "^11.4.1",
     "prettier": "^1.10.2",
     "promise-retry": "^1.1.1",

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -1324,6 +1324,7 @@ class Hemera extends EventEmitter {
     hemera._execute = null
     hemera._defer = pDefer()
     hemera._actCallback = null
+    hemera.sid = 0
 
     // topic is needed to subscribe on a subject in NATS
     if (!pattern.topic) {
@@ -1432,13 +1433,17 @@ class Hemera extends EventEmitter {
     } else {
       const optOptions = {}
       // limit on the number of responses the requestor may receive
-      if (self._pattern.maxMessages$ > 0 || self._pattern.expectedMessages$ > 0) {
-        optOptions.max = self._pattern.expectedMessages$ || self._pattern.maxMessages$
+      if (
+        self._pattern.maxMessages$ > 0 ||
+        self._pattern.expectedMessages$ > 0
+      ) {
+        optOptions.max =
+          self._pattern.expectedMessages$ || self._pattern.maxMessages$
       } else if (self._pattern.maxMessages$ !== -1) {
         optOptions.max = 1
       }
       // send request
-      self._sid = self._transport.sendRequest(
+      self.sid = self._transport.sendRequest(
         self._pattern.topic,
         self._request.payload,
         optOptions,
@@ -1485,7 +1490,7 @@ class Hemera extends EventEmitter {
       )
     }
 
-    self._transport.timeout(self._sid, timeout, expectedMsg, timeoutHandler)
+    self._transport.timeout(self.sid, timeout, expectedMsg, timeoutHandler)
   }
 
   /**

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -959,7 +959,7 @@ class Hemera extends EventEmitter {
           return
         }
 
-        // user cancels the request early
+        // the user can cancel the request early
         if (self._reply.finished) {
           self.respond()
           return
@@ -980,6 +980,7 @@ class Hemera extends EventEmitter {
             self.respond(err, result)
           )
         } else {
+          // we expect to provide promise style
           let result = action(self._request.payload.pattern)
           const isPromise = result && typeof result.then === 'function'
 
@@ -1440,8 +1441,8 @@ class Hemera extends EventEmitter {
     } else {
       const optOptions = {
         timeout: self._pattern.timeout$ || self.config.timeout,
-        // default is request-reply semantic but we can assign -1
-        // to define no limit but the user has to unsubscribe it
+        // default is request-reply semantic but we can assign -1 (no limit)
+        // but the user has to unsubscribe it
         max: 1
       }
       // limit on the number of responses the requestor may receive
@@ -1462,7 +1463,7 @@ class Hemera extends EventEmitter {
         resp => self._sendRequestHandler(resp)
       )
 
-      // create timeout handler only when with combination of expected msg
+      // create timeout handler only with a combination of expected msg
       // the default timeout handler is created by NATS
       if (self._pattern.expectedMessages$ > 0) {
         self._handleTimeout()

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -1432,8 +1432,8 @@ class Hemera extends EventEmitter {
     } else {
       const optOptions = {}
       // limit on the number of responses the requestor may receive
-      if (self._pattern.maxMessages$ > 0) {
-        optOptions.max = self._pattern.maxMessages$
+      if (self._pattern.maxMessages$ > 0 || self._pattern.expectedMessages$ > 0) {
+        optOptions.max = self._pattern.expectedMessages$ || self._pattern.maxMessages$
       } else if (self._pattern.maxMessages$ !== -1) {
         optOptions.max = 1
       }
@@ -1460,10 +1460,13 @@ class Hemera extends EventEmitter {
   handleTimeout() {
     const self = this
     const timeout = self._pattern.timeout$ || this._config.timeout
-    const expectedMsg =
-      (self._pattern.expectedMessages$ > 0
-        ? self._pattern.expectedMessages$
-        : self._pattern.maxMessages$) || 1
+    let expectedMsg = 1
+
+    if (self._pattern.expectedMessages$ > 0) {
+      expectedMsg = self._pattern.expectedMessages$
+    } else if (self._pattern.maxMessages$) {
+      expectedMsg = null
+    }
 
     let timeoutHandler = () => {
       const error = new Errors.TimeoutError(

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -1455,12 +1455,15 @@ class Hemera extends EventEmitter {
    * - Service is actually still processing the request (service takes too long)
    * - Service was processing the request but crashed (service error)
    *
-   *
    * @memberOf Hemera
    */
   handleTimeout() {
     const self = this
     const timeout = self._pattern.timeout$ || this._config.timeout
+    const expectedMsg =
+      (self._pattern.expectedMessages$ > 0
+        ? self._pattern.expectedMessages$
+        : self._pattern.maxMessages$) || 1
 
     let timeoutHandler = () => {
       const error = new Errors.TimeoutError(
@@ -1479,7 +1482,7 @@ class Hemera extends EventEmitter {
       )
     }
 
-    self._transport.timeout(self._sid, timeout, 1, timeoutHandler)
+    self._transport.timeout(self._sid, timeout, expectedMsg, timeoutHandler)
   }
 
   /**

--- a/packages/hemera/package.json
+++ b/packages/hemera/package.json
@@ -51,11 +51,11 @@
     "joi": "11.1.x",
     "lodash": "4.17.x",
     "p-defer": "1.0.x",
-    "pino": "4.11.x",
+    "pino": "4.13.0",
     "super-error": "2.2.x",
     "tinysonic": "1.3.x"
   },
   "peerDependencies": {
-    "nats": ">= 0.7.2"
+    "nats": "0.8.x"
   }
 }

--- a/test/hemera/timeouts.spec.js
+++ b/test/hemera/timeouts.spec.js
@@ -207,6 +207,50 @@ describe('Timeouts', function() {
       }, 300)
     })
   })
+
+  it('Should not timeout when more messages than expected are send because the INBOX is closed automatically', function(done) {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    let error = 0
+    let result = 0
+
+    hemera.ready(() => {
+      hemera.add(
+        {
+          topic: 'test',
+          cmd: 'A'
+        },
+        function(resp) {
+          for (let i = 0; i < 10; i++) {
+            this.reply(i)
+          }
+        }
+      )
+
+      hemera.act(
+        {
+          topic: 'test',
+          cmd: 'A',
+          expectedMessages$: 5
+        },
+        function(err, resp) {
+          if (err) {
+            error++
+          } else {
+            result++
+          }
+        }
+      )
+
+      setTimeout(() => {
+        expect(error).to.be.equals(0)
+        expect(result).to.be.equals(5)
+        hemera.close(done)
+      }, 300)
+    })
+  })
 })
 
 describe('Timeouts', function() {

--- a/test/hemera/timeouts.spec.js
+++ b/test/hemera/timeouts.spec.js
@@ -90,7 +90,7 @@ describe('Timeouts', function() {
     })
   })
 
-  it('Should not receive more messages with maxMessages$ set when the INBOX timeouts', function(done) {
+  it('Should not receive more messages when multiple participants timeouts', function(done) {
     const nats = require('nats').connect(authUrl)
 
     const hemera = new Hemera(nats)
@@ -144,8 +144,7 @@ describe('Timeouts', function() {
         {
           topic: 'test',
           cmd: 'B',
-          timeout$: 150,
-          maxMessages$: 10
+          timeout$: 150
         },
         function(err, resp) {
           if (err) {
@@ -161,6 +160,49 @@ describe('Timeouts', function() {
         expect(aResult).to.be.equals(0)
         expect(bError).to.be.equals(1)
         expect(bResult).to.be.equals(0)
+        hemera.close(done)
+      }, 300)
+    })
+  })
+
+  it('Should receive timeout when expected count of messages could not be received', function(done) {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    let error = 0
+    let result = 0
+
+    hemera.ready(() => {
+      hemera.add(
+        {
+          topic: 'test',
+          cmd: 'A'
+        },
+        (resp, cb) => {
+          cb()
+        }
+      )
+
+      hemera.act(
+        {
+          topic: 'test',
+          cmd: 'A',
+          timeout$: 100,
+          expectedMessages$: 2
+        },
+        function(err, resp) {
+          if (err) {
+            error++
+          } else {
+            result++
+          }
+        }
+      )
+
+      setTimeout(() => {
+        expect(error).to.be.equals(1)
+        expect(result).to.be.equals(1)
         hemera.close(done)
       }, 300)
     })

--- a/test/hemera/unsubscribing.spec.js
+++ b/test/hemera/unsubscribing.spec.js
@@ -178,7 +178,7 @@ describe('Unsubscribe NATS topic', function() {
         function(err, resp) {
           expect(err).to.be.not.exists()
 
-          const result = hemera.remove(this._sid)
+          const result = hemera.remove(this.sid)
           expect(result).to.be.equals(true)
           hemera.close(done)
         }


### PR DESCRIPTION
This PR will add the `expectedMessages$` flag which can be used to require a specific count of messages before a timeout error is thrown.

The default timeout handler isn't created anymore with `nats.timeout` but will be handled in the callback function of the requestor.

Other changes:
- make request-reply `sid` inside act context public
- update pino logger,
- update nats peerDep
- update docs