### PR TITLE
promise support for close method

### DIFF
--- a/test/hemera/gracefully-shutdown.spec.js
+++ b/test/hemera/gracefully-shutdown.spec.js
@@ -287,20 +287,14 @@ describe('Gracefully shutdown', function() {
       logLevel: 'silent'
     })
 
-    let callback = Sinon.spy()
-
     hemera.ready(() => {
-      hemera.on('error', err => {
-        expect(err.message).to.be.equals('test')
-        callback()
-      })
       hemera.ext('onClose', function(ctx, next) {
         next(new Error('test'))
       })
       hemera.close(err => {
         expect(err).to.be.exists()
+        expect(err.message).to.be.equals('test')
         expect(nats.closed).to.be.equals(true)
-        expect(callback.called).to.be.equals(true)
         done()
       })
     })

--- a/test/hemera/onClose.spec.js
+++ b/test/hemera/onClose.spec.js
@@ -72,15 +72,13 @@ describe('onClose extension', function() {
 
     hemera.use(plugin)
 
-    hemera.on('error', err => {
-      expect(err.message).to.be.equals('test')
-      done()
-    })
-
-    hemera.ready(x => {
-      hemera.close(x => {
+    hemera.ready(err => {
+      expect(err).to.be.not.exists()
+      hemera.close(err => {
+        expect(err.message).to.be.equals('test')
         expect(secondOnCloseHandler.callCount).to.be.equals(1)
         expect(firstOnCloseHandler.callCount).to.be.equals(1)
+        done()
       })
     })
   })


### PR DESCRIPTION
This PR will implement support for promises for the `close` method. We also removed the emit of `close` errors rather pass them with callback or promise style.