### PR TITLE
Feature/refactor promise cb handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ const start = async () => {
     await hemera.ready()
     hemera.log.info(`service listening`)
     // start request
-    const result = await hemera.act({
+    const response = await hemera.act({
       topic: 'math',
       cmd: 'add',
       a: 10,
       b: 10
     })
-    hemera.log.info(result)
+    hemera.log.info(response.data)
   } catch (err) {
     hemera.log.error(err)
     process.exit(1)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ const hemera = new Hemera(nats, {
 hemera.use(HemeraJoi)
 hemera.setOption('payloadValidator', 'hemera-joi')
 
+// use exposed lib from plugin
 let Joi = hemera.joi
+
+// define your first sever action
 hemera.add(
   {
     topic: 'math',
@@ -88,11 +91,19 @@ hemera.add(
 
 const start = async () => {
   try {
-    // bootstrap hemera
+    // establish connection and bootstrap hemera
     await hemera.ready()
     hemera.log.info(`service listening`)
-    // start request
-    const response = await hemera.act({
+    // start first request
+    let response = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 10,
+      b: 10
+    })
+    hemera.log.info(response.data)
+    // keep the parent context e.g metadata, delegate
+    response = await response.context.act({
       topic: 'math',
       cmd: 'add',
       a: 10,

--- a/benchmark/request_perf_async_await.js
+++ b/benchmark/request_perf_async_await.js
@@ -19,21 +19,18 @@ hemera.ready(() => {
   var start = new Date()
 
   for (var i = 0; i < loop; i++) {
-    hemera.act(
-      {
+    hemera
+      .act({
         topic: 'math',
         cmd: 'add',
         a: 1,
         b: 2
-      },
-      async function(err, resp) {
-        await {}
-      }
-    )
-
-    if (i % hash === 0) {
-      process.stdout.write('+')
-    }
+      })
+      .then(() => {
+        if (i % hash === 0) {
+          process.stdout.write('+')
+        }
+      })
   }
 
   hemera.close(function() {

--- a/benchmark/request_rt_async_await.js
+++ b/benchmark/request_rt_async_await.js
@@ -29,20 +29,17 @@ hemera1.ready(() => {
   )
 
   // Need to flush here since using separate connections.
-  hemera1.transport.flush(() => {
+  hemera1.transport.flush(async () => {
     for (var i = 0; i < loop; i++) {
-      hemera2.act(
-        {
+      hemera2
+        .act({
           topic: 'math',
           cmd: 'add',
           a: 1,
           b: 2,
           maxMessages$: 1
-        },
-        function(err, resp) {
-          if (err) {
-            throw err
-          }
+        })
+        .then(() => {
           received += 1
 
           if (received === loop) {
@@ -55,8 +52,7 @@ hemera1.ready(() => {
           } else if (received % hash === 0) {
             process.stdout.write('+')
           }
-        }
-      )
+        })
     }
   })
 })

--- a/docs/1_extension_points.html
+++ b/docs/1_extension_points.html
@@ -293,7 +293,7 @@ hemera.ext("onClientPreRequest", function(hemera, next) {
 </code>
                     </pre>
           <ul>
-            <code>hemera</code> current hemera instance</li>
+            <li><code>hemera</code> current hemera instance</li>
           </ul>
           <br>
           <h4 class="section-h4">Server</h4>

--- a/docs/1_pub_sub.html
+++ b/docs/1_pub_sub.html
@@ -188,14 +188,14 @@ hemera.add({
   pubsub$: true,
   topic: "math",
   cmd: "add"
-}, async function () {
+}, async function (req) {
+  return req.a + req.b
 })
 
 const result = await hemera.act({
   pubsub$: true,
   topic: "math",
   cmd: "add"
-}, async function () {
 })
 </code>
                     </pre>
@@ -225,7 +225,7 @@ const result = await hemera.act({
     <!-- Highlights JS -->
     <script src="scripts/prism.min.js"></script>
     <script>
-        
+
     </script>
 
 </body>

--- a/docs/1_pub_sub.html
+++ b/docs/1_pub_sub.html
@@ -197,6 +197,9 @@ const result = await hemera.act({
   topic: "math",
   cmd: "add"
 })
+
+result.data
+result.context
 </code>
                     </pre>
                 </div>

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -422,6 +422,9 @@ const result = await hemera.act({
   topic: "math",
   cmd: "add",
 })
+
+result.data
+result.context
 </code>
                     </pre>
         </div>

--- a/docs/1_request_reply.html
+++ b/docs/1_request_reply.html
@@ -421,8 +421,6 @@ hemera.add({
 const result = await hemera.act({
   topic: "math",
   cmd: "add",
-}, async function (req) {
-  return await req.a + req.b
 })
 </code>
                     </pre>

--- a/docs/2_basic.html
+++ b/docs/2_basic.html
@@ -2,135 +2,286 @@
 <html>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Hemera</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,800">
-    <link rel="stylesheet" href="stylesheets/github-gist.css">
-    <link rel="stylesheet" href="stylesheets/styles.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hemera</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,800">
+  <link rel="stylesheet" href="stylesheets/github-gist.css">
+  <link rel="stylesheet" href="stylesheets/styles.css">
 </head>
 
 <body>
 
-    <!-- BEGIN NAVIGATION BAR -->
-    <nav class="navbar navbar-default navbar-fixed-top">
-        <div class="container">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
-                    aria-controls="navbar">
-				<span class="sr-only">Toggle navigation</span>
-				<span class="icon-bar"></span>
-				<span class="icon-bar"></span>
-				<span class="icon-bar"></span>
-			</button>
-                <a class="navbar-brand" href="https://github.com/hemerajs/hemera"><img src="images/logo.png" height="36px"></a>
-            </div>
-            <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav navbar-right">
-                    <li class="active"><a href="index.html">Hemera</a></li>
-                    <li><a href="https://github.com/hemerajs/hemera">GitHub</a></li>
-                </ul>
-            </div>
-            <!--/.nav-collapse -->
+  <!-- BEGIN NAVIGATION BAR -->
+  <nav class="navbar navbar-default navbar-fixed-top">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+          aria-controls="navbar">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="https://github.com/hemerajs/hemera">
+          <img src="images/logo.png" height="36px">
+        </a>
+      </div>
+      <div id="navbar" class="navbar-collapse collapse">
+        <ul class="nav navbar-nav navbar-right">
+          <li class="active">
+            <a href="index.html">Hemera</a>
+          </li>
+          <li>
+            <a href="https://github.com/hemerajs/hemera">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <!--/.nav-collapse -->
+    </div>
+  </nav>
+  <!-- END NAVIGATION BAR -->
+
+  <div class="container body-container">
+    <div class="main-content">
+      <div class="row">
+
+        <!-- BEGIN SIDEBAR -->
+        <div class="col-sm-3 border-right section-left">
+          <div saveheight="1" class="sidebar-nav">
+            <h4>INTRODUCTION</h4>
+            <ul>
+              <li>
+                <a href="index.html">
+                  <span>Introduction</span>
+                </a>
+              </li>
+              <li>
+                <a href="getting-started.html">
+                  <span>Getting Started</span>
+                </a>
+              </li>
+              <li>
+                <a href="packages.html">
+                  <span>Packages</span>
+                </a>
+              </li>
+            </ul>
+
+            <h4>1. Basics</h4>
+            <ul>
+              <li>
+                <a href="1_request_reply.html">
+                  <span>Request & Reply</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_pattern_matching.html">
+                  <span>Pattern matching</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_pub_sub.html">
+                  <span>Publish & Subscribe</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_payload_validation.html">
+                  <span>Payload validation</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_middleware.html">
+                  <span>Middleware</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_extension_points.html">
+                  <span>Extension Points</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_logging.html">
+                  <span>Logging</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_plugins.html">
+                  <span>Plugins</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_metadata.html">
+                  <span>Metadata</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_context.html">
+                  <span>Context</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_delegate.html">
+                  <span>Delegate</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_life_cycle_events.html">
+                  <span>Life-cycle events</span>
+                </a>
+              </li>
+            </ul>
+
+            <h4>2. ERROR HANDLING</h4>
+            <ul>
+              <li>
+                <a href="2_basic.html" class="active">
+                  <span>Basic</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_timeout_errors.html">
+                  <span>Timeout errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_fatal_errors.html">
+                  <span>Fatal errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_error_propagation.html">
+                  <span>Error propagation</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_transport_errors.html">
+                  <span>Listen on transport errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_response_errors.html">
+                  <span>Listen on response errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_custom_timeout.html">
+                  <span>Custom timeout per Act</span>
+                </a>
+              </li>
+            </ul>
+
+            <h4>3. Internals</h4>
+            <ul>
+              <li>
+                <a href="4_overview.html">
+                  <span>Protocol</span>
+                </a>
+              </li>
+              <li>
+                <a href="4_api.html">
+                  <span>API</span>
+                </a>
+              </li>
+            </ul>
+
+            <h4>4. ADVANCED</h4>
+            <ul>
+              <li>
+                <a href="5_clustering.html">
+                  <span>Clustering</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_api_versioning.html">
+                  <span>API Versioning</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_nats_limits.html">
+                  <span>Nats limits & features</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_testing.html">
+                  <span>Testing</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_bridge.html">
+                  <span>Bridge</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_nginx_integration_for_nats.html">
+                  <span>Nginx integration for NATS</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_contributing.html">
+                  <span>Contributing</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_hemera_vs_seneca.html">
+                  <span>Hemera vs Seneca</span>
+                </a>
+              </li>
+            </ul>
+
+            <h4>5. TOOLING</h4>
+            <ul>
+              <li>
+                <a href="6_monitoring.html">
+                  <span>Monitoring</span>
+                </a>
+              </li>
+              <li>
+                <a href="6_zipkin.html">
+                  <span>Zipkin</span>
+                </a>
+              </li>
+              <li>
+                <a href="6_cli.html">
+                  <span>CLI</span>
+                </a>
+              </li>
+            </ul>
+            <h4>6. BEST PRACTICE</h4>
+            <ul>
+              <li>
+                <a href="7_docker.html">
+                  <span>Docker</span>
+                </a>
+              </li>
+            </ul>
+
+          </div>
         </div>
-    </nav>
-    <!-- END NAVIGATION BAR -->
+        <!-- END SIDEBAR -->
 
-    <div class="container body-container">
-        <div class="main-content">
-            <div class="row">
+        <!-- BEGIN CONTENT -->
+        <div class="col-sm-9 border-left section-right">
+          <h1 class="section-header">Basic</h1>
+          <hr>
 
-                <!-- BEGIN SIDEBAR -->
-                <div class="col-sm-3 border-right section-left">
-                    <div saveheight="1" class="sidebar-nav">
-                        <h4>INTRODUCTION</h4>
-                        <ul>
-                            <li><a href="index.html"><span>Introduction</span></a></li>
-                            <li><a href="getting-started.html"><span>Getting Started</span></a></li>
-                            <li><a href="packages.html"><span>Packages</span></a></li>
-                        </ul>
-
-                        <h4>1. Basics</h4>
-                        <ul>
-                            <li><a href="1_request_reply.html"><span>Request & Reply</span></a></li>
-                            <li><a href="1_pattern_matching.html"><span>Pattern matching</span></a></li>
-                            <li><a href="1_pub_sub.html"><span>Publish & Subscribe</span></a></li>
-                            <li><a href="1_payload_validation.html"><span>Payload validation</span></a></li>
-                            <li><a href="1_middleware.html"><span>Middleware</span></a></li>
-                            <li><a href="1_extension_points.html"><span>Extension Points</span></a></li>
-                            <li><a href="1_logging.html"><span>Logging</span></a></li>
-                            <li><a href="1_plugins.html"><span>Plugins</span></a></li>
-                            <li><a href="1_metadata.html"><span>Metadata</span></a></li>
-                            <li><a href="1_context.html"><span>Context</span></a></li>
-                            <li><a href="1_delegate.html"><span>Delegate</span></a></li>
-                            <li><a href="1_life_cycle_events.html"><span>Life-cycle events</span></a></li>
-                        </ul>
-
-                        <h4>2. ERROR HANDLING</h4>
-                        <ul>
-                            <li><a href="2_basic.html" class="active"><span>Basic</span></a></li>
-                            <li><a href="2_timeout_errors.html"><span>Timeout errors</span></a></li>
-                            <li><a href="2_fatal_errors.html"><span>Fatal errors</span></a></li>
-                            <li><a href="2_error_propagation.html"><span>Error propagation</span></a></li>
-                            <li><a href="2_transport_errors.html"><span>Listen on transport errors</span></a></li>
-                            <li><a href="2_response_errors.html"><span>Listen on response errors</span></a></li>
-                            <li><a href="2_custom_timeout.html"><span>Custom timeout per Act</span></a></li>
-                        </ul>
-
-                        <h4>3. Internals</h4>
-                        <ul>
-                            <li><a href="4_overview.html"><span>Protocol</span></a></li>
-                            <li><a href="4_api.html"><span>API</span></a></li>
-                        </ul>
-
-                        <h4>4. ADVANCED</h4>
-                        <ul>
-                            <li><a href="5_clustering.html"><span>Clustering</span></a></li>
-                            <li><a href="5_api_versioning.html"><span>API Versioning</span></a></li>
-                            <li><a href="5_nats_limits.html"><span>Nats limits & features</span></a></li>
-                            <li><a href="5_testing.html"><span>Testing</span></a></li>
-                            <li><a href="5_bridge.html"><span>Bridge</span></a></li>
-                            <li><a href="5_nginx_integration_for_nats.html"><span>Nginx integration for NATS</span></a></li>
-                            <li><a href="5_contributing.html"><span>Contributing</span></a></li>
-                            <li><a href="5_hemera_vs_seneca.html"><span>Hemera vs Seneca</span></a></li>
-                        </ul>
-
-                        <h4>5. TOOLING</h4>
-                        <ul>
-                            <li><a href="6_monitoring.html"><span>Monitoring</span></a></li>
-                            <li><a href="6_zipkin.html"><span>Zipkin</span></a></li>
-                            <li><a href="6_cli.html"><span>CLI</span></a></li>
-                        </ul>
-                        <h4>6. BEST PRACTICE</h4>
-                        <ul>
-                            <li><a href="7_docker.html"><span>Docker</span></a></li>
-                        </ul>
-
-                    </div>
-                </div>
-                <!-- END SIDEBAR -->
-
-                <!-- BEGIN CONTENT -->
-                <div class="col-sm-9 border-left section-right">
-                    <h1 class="section-header">Basic</h1>
-                    <hr>
-
-                    <p class="section-content">
-                    </p>
-                    <h4 class="section-h4">Synchronous errors</h4>
-                    <p>By default, Hemera will catch any exception thrown within the initial synchronous execution of a request and pass it along to the next error-handling middleware or gracefully exit the process:</p>
-                    <pre>
+          <p class="section-content">
+          </p>
+          <h4 class="section-h4">Synchronous errors</h4>
+          <p>By default, Hemera will catch any exception thrown within the initial synchronous execution of a request and pass
+            it along to the next error-handling middleware or gracefully exit the process:</p>
+          <pre>
 <code class="language-javascript">
 hemera.add({ topic: "math", cmd: "add" }, function (req, cb) {
   throw new Error()
 })
 </code>
                     </pre>
-                    <h4 class="section-h4">Asynchronous errors</h4>
-                    <p>In asynchronous code, Hemera cannot catch exceptions as you’ve lost your stack once you have entered a callback:</p>
-                    <pre>
+          <h4 class="section-h4">Asynchronous errors</h4>
+          <p>In asynchronous code, Hemera cannot catch exceptions as you’ve lost your stack once you have entered a callback:</p>
+          <pre>
 <code class="language-javascript">
 hemera.add({ topic: "math", cmd: "add" }, function (req, cb) {
   process.nextTick(() => {
@@ -139,25 +290,26 @@ hemera.add({ topic: "math", cmd: "add" }, function (req, cb) {
 })
 </code>
                     </pre>
-                    <p>"How can I deal with them in a proper way?" Read this <a href="https://strongloop.com/strongblog/async-error-handling-expressjs-es7-promises-generators/">article</a> about async error handling in express its very useful.</p>
-                    <h4 class="section-h4">For these cases, use the callback function to propagate errors:</h4>
-                    <pre>
+          <p>"How can I deal with them in a proper way?" Read this
+            <a href="https://strongloop.com/strongblog/async-error-handling-expressjs-es7-promises-generators/">article</a> about async error handling in express its very useful.</p>
+          <h4 class="section-h4">For these cases, use the callback function to propagate errors:</h4>
+          <pre>
 <code class="language-javascript">
 hemera.add({ topic: "math", cmd: "add" }, function (req, cb) {
   cb(new CustomError("Invalid operation"))
 })
 </code>
                     </pre>
-                    <h4 class="section-h4">Hemera strictly follows the Error-first-callback convention.</h4>
-                    <pre>
+          <h4 class="section-h4">Hemera strictly follows the Error-first-callback convention.</h4>
+          <pre>
 <code class="language-javascript">
 hemera.act({ topic: "math", cmd: "add", a: 1, b: 1 }, function (err, resp) {
  err instanceOf CustomError // true
 })
 </code>
                     </pre>
-                    <h4 class="section-h4">Create custom errors</h4>
-                    <pre>
+          <h4 class="section-h4">Create custom errors</h4>
+          <pre>
 <code class="language-javascript">
 const UnauthorizedError = Hemera.createError("Unauthorized")
 
@@ -179,31 +331,31 @@ hemera.act({
 })
 </code>
                     </pre>
-                </div>
-                <!-- END CONTENT -->
-
-            </div>
-            <!-- /row -->
         </div>
-        <!-- /main-content -->
+        <!-- END CONTENT -->
+
+      </div>
+      <!-- /row -->
     </div>
-    <!-- /container -->
+    <!-- /main-content -->
+  </div>
+  <!-- /container -->
 
-    <!-- BEGIN FOOTER -->
-    <footer class="navbar-fixed-bottom">
-        <div class="container footer">
-            <p>
-            </p>
-        </div>
-    </footer>
-    <!-- END FOOTER -->
+  <!-- BEGIN FOOTER -->
+  <footer class="navbar-fixed-bottom">
+    <div class="container footer">
+      <p>
+      </p>
+    </div>
+  </footer>
+  <!-- END FOOTER -->
 
-    <!-- Bootstrap JS -->
-    <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <!-- Bootstrap JS -->
+  <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
-    <!-- Highlights JS -->
-    <script src="scripts/prism.min.js"></script>
+  <!-- Highlights JS -->
+  <script src="scripts/prism.min.js"></script>
 
 </body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,203 +2,390 @@
 <html>
 
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Hemera</title>
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css" />
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,800">
-	<link rel="stylesheet" href="stylesheets/github-gist.css">
-	<link rel="stylesheet" href="stylesheets/styles.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hemera</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,800">
+  <link rel="stylesheet" href="stylesheets/github-gist.css">
+  <link rel="stylesheet" href="stylesheets/styles.css">
 </head>
 
 <body>
 
-	<!-- BEGIN NAVIGATION BAR -->
-	<nav class="navbar navbar-default navbar-fixed-top">
-		<div class="container">
-			<div class="navbar-header">
-				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
-				  aria-controls="navbar">
-				<span class="sr-only">Toggle navigation</span>
-				<span class="icon-bar"></span>
-				<span class="icon-bar"></span>
-				<span class="icon-bar"></span>
-			</button>
-				<a class="navbar-brand" href="https://github.com/hemerajs/hemera"><img src="images/logo.png" height="36px"></a>
-			</div>
-			<div id="navbar" class="navbar-collapse collapse">
-				<ul class="nav navbar-nav navbar-right">
-					<li class="active"><a href="index.html">Hemera</a></li>
-					<li><a href="https://github.com/hemerajs/hemera">GitHub</a></li>
-				</ul>
-			</div>
-			<!--/.nav-collapse -->
-		</div>
-	</nav>
-	<!-- END NAVIGATION BAR -->
+  <!-- BEGIN NAVIGATION BAR -->
+  <nav class="navbar navbar-default navbar-fixed-top">
+    <div class="container">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false"
+          aria-controls="navbar">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand" href="https://github.com/hemerajs/hemera">
+          <img src="images/logo.png" height="36px">
+        </a>
+      </div>
+      <div id="navbar" class="navbar-collapse collapse">
+        <ul class="nav navbar-nav navbar-right">
+          <li class="active">
+            <a href="index.html">Hemera</a>
+          </li>
+          <li>
+            <a href="https://github.com/hemerajs/hemera">GitHub</a>
+          </li>
+        </ul>
+      </div>
+      <!--/.nav-collapse -->
+    </div>
+  </nav>
+  <!-- END NAVIGATION BAR -->
 
-	<div class="container body-container">
-		<div class="main-content">
-			<div class="row">
+  <div class="container body-container">
+    <div class="main-content">
+      <div class="row">
 
-				<!-- BEGIN SIDEBAR -->
-				<div class="col-sm-3 border-right section-left">
-					<div saveheight="1" class="sidebar-nav">
-						<h4>INTRODUCTION</h4>
-						<ul>
-							<li><a href="index.html" class="active"><span>Introduction</span></a></li>
-							<li><a href="getting-started.html"><span>Getting Started</span></a></li>
-							<li><a href="packages.html"><span>Packages</span></a></li>
-						</ul>
+        <!-- BEGIN SIDEBAR -->
+        <div class="col-sm-3 border-right section-left">
+          <div saveheight="1" class="sidebar-nav">
+            <h4>INTRODUCTION</h4>
+            <ul>
+              <li>
+                <a href="index.html" class="active">
+                  <span>Introduction</span>
+                </a>
+              </li>
+              <li>
+                <a href="getting-started.html">
+                  <span>Getting Started</span>
+                </a>
+              </li>
+              <li>
+                <a href="packages.html">
+                  <span>Packages</span>
+                </a>
+              </li>
+            </ul>
 
-						<h4>1. Basics</h4>
-						<ul>
-							<li><a href="1_request_reply.html"><span>Request & Reply</span></a></li>
-							<li><a href="1_pattern_matching.html"><span>Pattern matching</span></a></li>
-							<li><a href="1_pub_sub.html"><span>Publish & Subscribe</span></a></li>
-							<li><a href="1_payload_validation.html"><span>Payload validation</span></a></li>
-							<li><a href="1_middleware.html"><span>Middleware</span></a></li>
-							<li><a href="1_extension_points.html"><span>Extension Points</span></a></li>
-							<li><a href="1_logging.html"><span>Logging</span></a></li>
-							<li><a href="1_plugins.html"><span>Plugins</span></a></li>
-							<li><a href="1_metadata.html"><span>Metadata</span></a></li>
-							<li><a href="1_context.html"><span>Context</span></a></li>
-							<li><a href="1_delegate.html"><span>Delegate</span></a></li>
-							<li><a href="1_life_cycle_events.html"><span>Life-cycle events</span></a></li>
-						</ul>
+            <h4>1. Basics</h4>
+            <ul>
+              <li>
+                <a href="1_request_reply.html">
+                  <span>Request & Reply</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_pattern_matching.html">
+                  <span>Pattern matching</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_pub_sub.html">
+                  <span>Publish & Subscribe</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_payload_validation.html">
+                  <span>Payload validation</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_middleware.html">
+                  <span>Middleware</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_extension_points.html">
+                  <span>Extension Points</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_logging.html">
+                  <span>Logging</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_plugins.html">
+                  <span>Plugins</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_metadata.html">
+                  <span>Metadata</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_context.html">
+                  <span>Context</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_delegate.html">
+                  <span>Delegate</span>
+                </a>
+              </li>
+              <li>
+                <a href="1_life_cycle_events.html">
+                  <span>Life-cycle events</span>
+                </a>
+              </li>
+            </ul>
 
-						<h4>2. ERROR HANDLING</h4>
-						<ul>
-							<li><a href="2_basic.html"><span>Basic</span></a></li>
-							<li><a href="2_timeout_errors.html"><span>Timeout errors</span></a></li>
-							<li><a href="2_fatal_errors.html"><span>Fatal errors</span></a></li>
-							<li><a href="2_error_propagation.html"><span>Error propagation</span></a></li>
-							<li><a href="2_transport_errors.html"><span>Listen on transport errors</span></a></li>
-							<li><a href="2_response_errors.html"><span>Listen on response errors</span></a></li>
-							<li><a href="2_custom_timeout.html"><span>Custom timeout per Act</span></a></li>
-						</ul>
+            <h4>2. ERROR HANDLING</h4>
+            <ul>
+              <li>
+                <a href="2_basic.html">
+                  <span>Basic</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_timeout_errors.html">
+                  <span>Timeout errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_fatal_errors.html">
+                  <span>Fatal errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_error_propagation.html">
+                  <span>Error propagation</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_transport_errors.html">
+                  <span>Listen on transport errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_response_errors.html">
+                  <span>Listen on response errors</span>
+                </a>
+              </li>
+              <li>
+                <a href="2_custom_timeout.html">
+                  <span>Custom timeout per Act</span>
+                </a>
+              </li>
+            </ul>
 
-						<h4>3. Internals</h4>
-						<ul>
-							<li><a href="4_overview.html"><span>Protocol</span></a></li>
-							<li><a href="4_api.html"><span>API</span></a></li>
-						</ul>
+            <h4>3. Internals</h4>
+            <ul>
+              <li>
+                <a href="4_overview.html">
+                  <span>Protocol</span>
+                </a>
+              </li>
+              <li>
+                <a href="4_api.html">
+                  <span>API</span>
+                </a>
+              </li>
+            </ul>
 
-						<h4>4. ADVANCED</h4>
-						<ul>
-							<li><a href="5_clustering.html"><span>Clustering</span></a></li>
-							<li><a href="5_api_versioning.html"><span>API Versioning</span></a></li>
-							<li><a href="5_nats_limits.html"><span>Nats limits & features</span></a></li>
-							<li><a href="5_testing.html"><span>Testing</span></a></li>
-							<li><a href="5_bridge.html"><span>Bridge</span></a></li>
-							<li><a href="5_nginx_integration_for_nats.html"><span>Nginx integration for NATS</span></a></li>
-							<li><a href="5_contributing.html"><span>Contributing</span></a></li>
-							<li><a href="5_hemera_vs_seneca.html"><span>Hemera vs Seneca</span></a></li>
-						</ul>
+            <h4>4. ADVANCED</h4>
+            <ul>
+              <li>
+                <a href="5_clustering.html">
+                  <span>Clustering</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_api_versioning.html">
+                  <span>API Versioning</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_nats_limits.html">
+                  <span>Nats limits & features</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_testing.html">
+                  <span>Testing</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_bridge.html">
+                  <span>Bridge</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_nginx_integration_for_nats.html">
+                  <span>Nginx integration for NATS</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_contributing.html">
+                  <span>Contributing</span>
+                </a>
+              </li>
+              <li>
+                <a href="5_hemera_vs_seneca.html">
+                  <span>Hemera vs Seneca</span>
+                </a>
+              </li>
+            </ul>
 
-						<h4>5. TOOLING</h4>
-						<ul>
-							<li><a href="6_monitoring.html"><span>Monitoring</span></a></li>
-							<li><a href="6_zipkin.html"><span>Zipkin</span></a></li>
-							<li><a href="6_cli.html"><span>CLI</span></a></li>
-						</ul>
-						<h4>6. BEST PRACTICE</h4>
-						<ul>
-							<li><a href="7_docker.html"><span>Docker</span></a></li>
-						</ul>
+            <h4>5. TOOLING</h4>
+            <ul>
+              <li>
+                <a href="6_monitoring.html">
+                  <span>Monitoring</span>
+                </a>
+              </li>
+              <li>
+                <a href="6_zipkin.html">
+                  <span>Zipkin</span>
+                </a>
+              </li>
+              <li>
+                <a href="6_cli.html">
+                  <span>CLI</span>
+                </a>
+              </li>
+            </ul>
+            <h4>6. BEST PRACTICE</h4>
+            <ul>
+              <li>
+                <a href="7_docker.html">
+                  <span>Docker</span>
+                </a>
+              </li>
+            </ul>
 
-					</div>
-				</div>
-				<!-- END SIDEBAR -->
+          </div>
+        </div>
+        <!-- END SIDEBAR -->
 
-				<!-- BEGIN CONTENT -->
-				<div class="col-sm-9 border-left section-right">
-					<h1 class="section-header">Introduction</h1>
+        <!-- BEGIN CONTENT -->
+        <div class="col-sm-9 border-left section-right">
+          <h1 class="section-header">Introduction</h1>
           <hr>
 
           <p class="hero__buttons">
-            <iframe src="https://ghbtns.com/github-btn.html?user=hemerajs&repo=hemera&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=hemerajs&repo=hemera&type=star&count=true&size=large" frameborder="0"
+              scrolling="0" width="160px" height="30px"></iframe>
           </p>
 
-					<p class="section-content">
-						<img class="section-image" src="images/logo-hemera.png" style="max-width: 100%">
-						<strong>Hemera</strong> is a small wrapper around the NATS driver. We want to provide a toolkit to develop micro services
-						in an easy and powerful way. We use pattern matching RPC style. You don't have to worry
-						about the transport. NATS is powerful.<br><br> A <strong>Hemera</strong> instance doesn't care about where other services
-						lives. You can start your service as many as you want on different hosts to ensure maximal availability. The only dependency
-						you have is a single binary of 7MB. Mind your own business NATS do the rest for you: <br><br>
-						<strong>NATS</strong> Server is a simple, high performance open source messaging system for cloud native applications,
-						IoT messaging, and microservices architectures. Companies like Ericsson, HTC, Siemens, VMware, Pivotal, GE and Baidu
-						rely on the NATS enterprise messaging system. <br><br>
-						<h4 class="section-header">Features</h4><br>
-						<ul>
-							<li><strong>Lightweight</strong>: The Hemera core is small as possible and can be extended by extensions or plugins.</li>
-							<li><strong>Location transparency</strong>: A service may be instantiated in different locations at different times. An
-								application interacting with an service and does not know the service physical location.</li>
-							<li><strong>Service Discovery</strong>: You don't need a service discovery all subscriptions are managed by NATS.</li>
-							<li><strong>Load Balancing</strong>: Requests are load balanced (random) by NATS mechanism of "queue groups".</li>
-							<li><strong>Packages</strong>: Providing reliable and modern plugins to the community.</li>
-							<li><strong>High performant</strong>: NATS is able to handle million of requests per second.</li>
-							<li><strong>Scalability</strong>: Filtering on the subject name enables services to divide work (perhaps with locality).</li>
-							<li><strong>Fault tolerance</strong>: Auto-heals when new services are added. Configure cluster mode to be more reliable.</li>
-							<li><strong>Auto-pruning</strong>: NATS automatically handles a slow consumer and cut it off.</li>
-							<li><strong>Pattern driven</strong>: Define the signatures of your RPC's in JSON and use the flexibility of pattern-matching.</li>
-							<li><strong>Request & Reply</strong>: By default point-to-point involves the fastest or first to respond.</li>
-							<li><strong>Publish & Subscribe</strong>: Hemera supports all features of NATS. This includes wildcards in subjects and normal publish
-								and fanout mechanism.</li>
-							<li><strong>Tracing</strong>: Any distributed system need good tracing capabilities. We provide support for Zipkin a tracing
-								system which manages both the collection and lookup of this data.</li>
-							<li><strong>Monitoring</strong>: Your NATS server can be monitored by cli or a dashboard.</li>
-							<li><strong>Payload validation</strong>: Create your own validator or use existing plugins e.g Hemera-Joi.</li>
-							<li><strong>Serialization</strong>: Use custom serializer e.g MessagePack.</li>
-							<li><strong>Metadata</strong>: Transfer metadata across services or attach contextual data to tracing systems.</li>
-							<li><strong>Dependencies</strong>: NATS is a single binary of 7MB and can be deployed in seconds.</li>
-						</ul>
-						<br>
-						<br>
-						<h4 class="section-header">What is your motivation?</h4>
-						<p class="section-header">We want to create a toolkit which is responsible for everything expect the transport. We don't need overall transport
-							independence. We trust in a well tested system. The wrong path in error-handling, logging and tracing are one of the
-							reasons why we couldn't use existing solutions.</p>
-						<br>
-						<h4>Be aware of your requirements</h4>
-						<p>Hemera has not been designed for high performance on a single process. It has been designed to create lots of microservices doesn't matter where they live. It choose simplicity and reliability as primary goals. It act together with NATS as central nervous system of your distributed system. Transport independency was not considered to be a relevant factor. In addition we use pattern matching which is very powerful. The fact that Hemera needs a broker is an argument which should be taken into consideration when you compare hemera with other frameworks. The relevant difference between microservice frameworks like senecajs, moleculer is not the performance or modularity its about the complexity you need to manage. Hemera is expert in providing an interface to work with lots of services in the network, NATS is the expert to deliver the message at the right place. Hemera is still a subscriber of NATS with some magic in routing and extensions. We don't have to worry about all different aspects in a distributed system like routing, load-balancing, service-discovery, clustering, health-checks ...</p>
-					</p>
-				</div>
-				<!-- END CONTENT -->
+          <p class="section-content">
+            <img class="section-image" src="images/logo-hemera.png" style="max-width: 100%">
+            <strong>Hemera</strong> is a small wrapper around the NATS driver. We want to provide a toolkit to develop micro services
+            in an easy and powerful way. We use pattern matching RPC style. You don't have to worry about the transport.
+            NATS is powerful.
+            <br>
+            <br> A
+            <strong>Hemera</strong> instance doesn't care about where other services lives. You can start your service as many as
+            you want on different hosts to ensure maximal availability. The only dependency you have is a single binary of
+            7MB. Mind your own business NATS do the rest for you:
+            <br>
+            <br>
+            <strong>NATS</strong> Server is a simple, high performance open source messaging system for cloud native applications,
+            IoT messaging, and microservices architectures. Companies like Ericsson, HTC, Siemens, VMware, Pivotal, GE and
+            Baidu rely on the NATS enterprise messaging system.
+            <br>
+            <br>
+            <h4 class="section-header">Features</h4>
+            <br>
+            <ul>
+              <li>
+                <strong>Lightweight</strong>: The Hemera core is small as possible and can be extended by extensions or plugins.</li>
+              <li>
+                <strong>Location transparency</strong>: A service may be instantiated in different locations at different times.
+                An application interacting with an service and does not know the service physical location.</li>
+              <li>
+                <strong>Service Discovery</strong>: You don't need a service discovery all subscriptions are managed by NATS.</li>
+              <li>
+                <strong>Load Balancing</strong>: Requests are load balanced (random) by NATS mechanism of "queue groups".</li>
+              <li>
+                <strong>Packages</strong>: Providing reliable and modern plugins to the community.</li>
+              <li>
+                <strong>High performant</strong>: NATS is able to handle million of requests per second.</li>
+              <li>
+                <strong>Scalability</strong>: Filtering on the subject name enables services to divide work (perhaps with locality).</li>
+              <li>
+                <strong>Fault tolerance</strong>: Auto-heals when new services are added. Configure cluster mode to be more reliable.</li>
+              <li>
+                <strong>Auto-pruning</strong>: NATS automatically handles a slow consumer and cut it off.</li>
+              <li>
+                <strong>Pattern driven</strong>: Define the signatures of your RPC's in JSON and use the flexibility of pattern-matching.</li>
+              <li>
+                <strong>Request & Reply</strong>: By default point-to-point involves the fastest or first to respond.</li>
+              <li>
+                <strong>Publish & Subscribe</strong>: Hemera supports all features of NATS. This includes wildcards in subjects and
+                normal publish and fanout mechanism.</li>
+              <li>
+                <strong>Tracing</strong>: Any distributed system need good tracing capabilities. We provide support for Zipkin a
+                tracing system which manages both the collection and lookup of this data.</li>
+              <li>
+                <strong>Monitoring</strong>: Your NATS server can be monitored by cli or a dashboard.</li>
+              <li>
+                <strong>Payload validation</strong>: Create your own validator or use existing plugins e.g Hemera-Joi.</li>
+              <li>
+                <strong>Serialization</strong>: Use custom serializer e.g MessagePack.</li>
+              <li>
+                <strong>Metadata</strong>: Transfer metadata across services or attach contextual data to tracing systems.</li>
+              <li>
+                <strong>Dependencies</strong>: NATS is a single binary of 7MB and can be deployed in seconds.</li>
+            </ul>
+            <br>
+            <br>
+            <h4 class="section-header">What is your motivation?</h4>
+            <p class="section-header">We want to create a toolkit which is responsible for everything expect the transport. We don't need overall transport
+              independence. We trust in a well tested system. The wrong path in error-handling, logging and tracing are one
+              of the reasons why we couldn't use existing solutions.</p>
+            <br>
+            <h4>Be aware of your requirements</h4>
+            <p>Hemera has not been designed for high performance on a single process. It has been designed to create lots of
+              microservices doesn't matter where they live. It choose simplicity and reliability as primary goals. It act
+              together with NATS as central nervous system of your distributed system. Transport independency was not considered
+              to be a relevant factor. In addition we use pattern matching which is very powerful. The fact that Hemera needs
+              a broker is an argument which should be taken into consideration when you compare hemera with other frameworks.
+              The relevant difference between microservice frameworks like senecajs, moleculer is not the performance or
+              modularity its about the complexity you need to manage. Hemera is expert in providing an interface to work
+              with lots of services in the network, NATS is the expert to deliver the message at the right place. Hemera
+              is still a subscriber of NATS with some magic in routing and extensions. We don't have to worry about all different
+              aspects in a distributed system like routing, load-balancing, service-discovery, clustering, health-checks
+              ...</p>
+          </p>
+        </div>
+        <!-- END CONTENT -->
 
-			</div>
-			<!-- /row -->
-		</div>
-		<!-- /main-content -->
-	</div>
-	<!-- /container -->
+      </div>
+      <!-- /row -->
+    </div>
+    <!-- /main-content -->
+  </div>
+  <!-- /container -->
 
-	<!-- BEGIN FOOTER -->
-	<footer class="navbar-fixed-bottom">
-		<div class="container footer">
-			<p>
-			</p>
-		</div>
-	</footer>
-	<!-- END FOOTER -->
+  <!-- BEGIN FOOTER -->
+  <footer class="navbar-fixed-bottom">
+    <div class="container footer">
+      <p>
+      </p>
+    </div>
+  </footer>
+  <!-- END FOOTER -->
 
-	<!-- Bootstrap JS -->
-	<script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <!-- Bootstrap JS -->
+  <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
-	<!-- Highlights JS -->
-	<script src="scripts/prism.min.js"></script>
-	<script>
+  <!-- Highlights JS -->
+  <script src="scripts/prism.min.js"></script>
+  <script>
 
-	</script>
-	<script>
-		((window.gitter = {}).chat = {}).options = {
-			room: 'hemerajs/hemera'
-		};
-	</script>
-	<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  </script>
+  <script>
+    ((window.gitter = {}).chat = {}).options = {
+      room: 'hemerajs/hemera'
+    };
+  </script>
+  <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
 
 </body>
 

--- a/examples/basic/async-await-nested.js
+++ b/examples/basic/async-await-nested.js
@@ -7,10 +7,6 @@ const hemera = new Hemera(nats, {
   logLevel: 'info'
 })
 
-hemera.ext('onServerPreRequest', async () => {
-  hemera.log.info('onServerPreRequest')
-})
-
 hemera.add(
   {
     topic: 'math',
@@ -26,13 +22,20 @@ const start = async () => {
     await hemera.ready()
     hemera.log.info(`service listening`)
     // start request
-    const out = await hemera.act({
+    let out = await hemera.act({
       topic: 'math',
       cmd: 'add',
       a: 10,
       b: 10
     })
-    hemera.log.info(out.data)
+    hemera.log.info(`result 1`, out.data)
+    out = await out.context.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 10,
+      b: 30
+    })
+    hemera.log.info(`result 2`, out.data)
   } catch (err) {
     hemera.log.error(err)
     process.exit(1)

--- a/examples/basic/promise-retry.js
+++ b/examples/basic/promise-retry.js
@@ -39,6 +39,6 @@ hemera.ready(() => {
       })
       .catch(retry)
   }, opt)
-    .then(value => console.log(value))
-    .catch(value => console.log(value))
+    .then(resp => console.log(resp.data))
+    .catch(err => console.error(err))
 })

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -42,7 +42,6 @@ const CodecPipeline = require('./codecPipeline')
 const Reply = require('./reply')
 const Add = require('./add')
 const Extension = require('./extension')
-const pDefer = require('p-defer')
 
 /**
  * @class Hemera
@@ -1046,14 +1045,17 @@ class Hemera extends EventEmitter {
       throw error
     }
 
+    // when sid was passed
     if (_.isNumber(topic)) {
       self._transport.unsubscribe(topic, maxMessages)
       return true
     } else {
+      // when topic name was passed
       const subId = self._topics[topic]
 
       if (subId) {
         self._transport.unsubscribe(subId, maxMessages)
+        // we remove all subscription related to this topic
         this.cleanTopic(topic)
         return true
       }
@@ -1121,6 +1123,7 @@ class Hemera extends EventEmitter {
         topic: definition.topic,
         pubsub: definition.pubsub$,
         maxMessages: definition.maxMessages$,
+        expectedMessages: definition.expectedMessages$,
         queue: definition.queue$
       }
     }
@@ -1131,8 +1134,6 @@ class Hemera extends EventEmitter {
       // set callback
       addDefinition.action = cb
     }
-
-    addDefinition.transport.topic = patternOnly.topic
 
     // Support full / token wildcards in subject
     // Convert nats wildcard tokens to RegexExp
@@ -1157,7 +1158,7 @@ class Hemera extends EventEmitter {
 
     // check for invalid topic subscriptions
     // it's not possible to register multiple patterns
-    // with different transport options to the same topic
+    // with different transport options with the same topic
     const def = this._checkForTransportCollision(addDefinition)
     if (def) {
       this.log.error(
@@ -1368,7 +1369,6 @@ class Hemera extends EventEmitter {
     hemera._request = new ClientRequest()
     hemera._isServer = false
     hemera._execute = null
-    hemera._defer = pDefer()
     hemera._actCallback = null
     hemera.sid = 0
 
@@ -1384,39 +1384,33 @@ class Hemera extends EventEmitter {
 
     if (cb) {
       hemera._actCallback = cb.bind(hemera)
-    }
-
-    hemera._execute = (err, result) => {
-      if (hemera._actCallback) {
-        const promise = hemera._actCallback(err, result)
-        if (promise) {
-          // check when using async / await
-          if (typeof promise.then === 'function') {
-            promise.then(hemera._defer.resolve).catch(hemera._defer.reject)
+      hemera._execute = hemera._actCallback
+      hemera._series(
+        hemera,
+        hemera._clientExtIterator,
+        hemera._ext['onClientPreRequest'],
+        err => hemera._onPreRequestCompleted(err)
+      )
+    } else {
+      const evaluateResult = new Promise((resolve, reject) => {
+        hemera._execute = (err, result) => {
+          if (err) {
+            reject(err)
           } else {
-            // when using callback style we always resolve with the function result
-            hemera._defer.resolve(promise)
+            resolve(result)
           }
         }
-        return
-      }
+      })
 
-      // when no callback was passed we handle it as promise style
-      if (err) {
-        hemera._defer.reject(err)
-      } else {
-        hemera._defer.resolve(result)
-      }
+      hemera._series(
+        hemera,
+        hemera._clientExtIterator,
+        hemera._ext['onClientPreRequest'],
+        err => hemera._onPreRequestCompleted(err)
+      )
+
+      return evaluateResult
     }
-
-    hemera._series(
-      hemera,
-      hemera._clientExtIterator,
-      hemera._ext['onClientPreRequest'],
-      err => hemera._onPreRequestCompleted(err)
-    )
-
-    return hemera._defer.promise
   }
 
   /**

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -1409,7 +1409,12 @@ class Hemera extends EventEmitter {
         err => hemera._onPreRequestCompleted(err)
       )
 
-      return evaluateResult
+      return evaluateResult.then(resp => {
+        return {
+          context: hemera,
+          data: resp
+        }
+      })
     }
   }
 

--- a/packages/hemera/package.json
+++ b/packages/hemera/package.json
@@ -50,7 +50,6 @@
     "hoek": "4.2.x",
     "joi": "11.1.x",
     "lodash": "4.17.x",
-    "p-defer": "1.0.x",
     "pino": "4.13.0",
     "super-error": "2.2.x",
     "tinysonic": "1.3.x"

--- a/test/hemera/async-await.js
+++ b/test/hemera/async-await.js
@@ -383,7 +383,7 @@ describe('Async / Await support', function() {
         function(resp) {}
       )
 
-      hemera.act({
+      await hemera.act({
         pubsub$: true,
         topic: 'math',
         cmd: 'add',
@@ -391,39 +391,6 @@ describe('Async / Await support', function() {
         b: 2
       })
 
-      hemera.close(done)
-    })
-  })
-
-  it('Should be able to pass an async function in pubsub mode', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(async () => {
-      hemera.add(
-        {
-          pubsub$: true,
-          topic: 'math',
-          cmd: 'add'
-        },
-        function(resp) {}
-      )
-
-      const a = await hemera.act(
-        {
-          pubsub$: true,
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        async () => {
-          return true
-        }
-      )
-
-      expect(a).to.be.equals(true)
       hemera.close(done)
     })
   })
@@ -547,19 +514,12 @@ describe('Async / Await support', function() {
       )
 
       hemera
-        .act(
-          {
-            topic: 'math',
-            cmd: 'add',
-            a: 1,
-            b: 2
-          },
-          async function(err, resp) {
-            expect(err).to.be.not.exists()
-
-            return resp
-          }
-        )
+        .act({
+          topic: 'math',
+          cmd: 'add',
+          a: 1,
+          b: 2
+        })
         .then(function(resp) {
           expect(resp).to.be.equals({
             result: true
@@ -574,45 +534,7 @@ describe('Async / Await support', function() {
 
     const hemera = new Hemera(nats)
 
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          await Promise.resolve({
-            result: true
-          })
-        }
-      )
-
-      hemera
-        .act(
-          {
-            topic: 'math',
-            cmd: 'add',
-            a: 1,
-            b: 2
-          },
-          async function(err, resp) {
-            expect(err).to.be.not.exists()
-            await Promise.reject(new Error('test'))
-          }
-        )
-        .catch(function(err) {
-          expect(err).to.be.exists()
-          hemera.close(done)
-        })
-    })
-  })
-
-  it('Should throw when rejection is unhandled', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
+    hemera.ready(async () => {
       hemera.add(
         {
           topic: 'math',
@@ -623,18 +545,17 @@ describe('Async / Await support', function() {
         }
       )
 
-      // in future we have to try catch it
-
-      hemera.act({
-        topic: 'math',
-        cmd: 'add',
-        a: 1,
-        b: 2
-      })
-
-      setTimeout(() => {
+      try {
+        await hemera.act({
+          topic: 'math',
+          cmd: 'add',
+          a: 1,
+          b: 2
+        })
+      } catch (err) {
+        expect(err).to.be.exists()
         hemera.close(done)
-      }, 50)
+      }
     })
   })
 
@@ -666,44 +587,6 @@ describe('Async / Await support', function() {
       setTimeout(() => {
         hemera.close(done)
       }, 50)
-    })
-  })
-
-  it('Should be able to catch an uncaught error in act', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          await Promise.resolve({
-            result: true
-          })
-        }
-      )
-
-      hemera
-        .act(
-          {
-            topic: 'math',
-            cmd: 'add',
-            a: 1,
-            b: 2
-          },
-          async function(err, resp) {
-            expect(err).to.be.not.exists()
-            throw new Error('test')
-          }
-        )
-        .catch(function(err) {
-          expect(err).to.be.exists()
-          hemera.close(done)
-        })
     })
   })
 })

--- a/test/hemera/async-await.js
+++ b/test/hemera/async-await.js
@@ -15,581 +15,424 @@ describe('Async / Await support', function() {
     server.kill()
   })
 
-  it('Should be able to await in add middleware', function(done) {
+  it('Should be able to await in add middleware', async function() {
     const nats = require('nats').connect(authUrl)
 
     const hemera = new Hemera(nats)
 
-    hemera.ready(() => {
-      hemera
-        .add({
-          topic: 'math',
-          cmd: 'add'
-        })
-        .use(async function(req, resp) {
-          await Promise.resolve()
-        })
-        .end(function(req, cb) {
-          cb(null, req.a + req.b)
-        })
+    await hemera.ready()
 
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        function(err, resp) {
-          expect(err).to.be.not.exists()
-          expect(resp).to.be.equals(3)
-          hemera.close(done)
-        }
-      )
+    hemera
+      .add({
+        topic: 'math',
+        cmd: 'add'
+      })
+      .use(async function(req, resp) {
+        await Promise.resolve()
+      })
+      .end(function(req, cb) {
+        cb(null, req.a + req.b)
+      })
+
+    const resp = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
     })
+
+    expect(resp.data).to.be.equals(3)
+    return hemera.close()
   })
 
-  it('Should be able to reply in middleware', function(done) {
+  it('Should be able to reply in middleware', async function() {
     const nats = require('nats').connect(authUrl)
 
     const hemera = new Hemera(nats)
 
-    hemera.ready(() => {
-      hemera
-        .add({
-          topic: 'math',
-          cmd: 'add'
-        })
-        .use(async function(req, resp) {
-          await resp.send({ a: 1 })
-        })
-        .end(function(req, cb) {
-          cb(null, req.a + req.b)
-        })
+    await hemera.ready()
 
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        function(err, resp) {
-          expect(err).to.be.not.exists()
-          expect(resp.a).to.be.equals(1)
-          hemera.close(done)
-        }
-      )
+    hemera
+      .add({
+        topic: 'math',
+        cmd: 'add'
+      })
+      .use(async function(req, resp) {
+        await resp.send({ a: 1 })
+      })
+      .end(function(req, cb) {
+        cb(null, req.a + req.b)
+      })
+
+    const resp = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
     })
+
+    expect(resp.data.a).to.be.equals(1)
+    return hemera.close()
   })
 
-  it('Should be able to reply an error in middleware', function(done) {
+  it('Should be able to reply an error in middleware', async function() {
     const nats = require('nats').connect(authUrl)
 
     const hemera = new Hemera(nats)
 
-    hemera.ready(() => {
-      hemera
-        .add({
-          topic: 'math',
-          cmd: 'add'
-        })
-        .use(async function(req, resp) {
-          await resp.send(new Error('test'))
-        })
-        .end(function(req, cb) {
-          cb(null, req.a + req.b)
-        })
+    await hemera.ready()
 
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        function(err, resp) {
-          expect(err).to.be.exists()
-          expect(err.name).to.be.equals('Error')
-          expect(err.message).to.be.equals('test')
-          hemera.close(done)
-        }
-      )
-    })
-  })
+    hemera
+      .add({
+        topic: 'math',
+        cmd: 'add'
+      })
+      .use(async function(req, resp) {
+        await resp.send(new Error('test'))
+      })
+      .end(function(req, cb) {
+        cb(null, req.a + req.b)
+      })
 
-  it('Should be able to await in end function of the middleware', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera
-        .add({
-          topic: 'math',
-          cmd: 'add'
-        })
-        .end(async function(req) {
-          const a = await Promise.resolve(req.a + req.b)
-          return a
-        })
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        function(err, resp) {
-          expect(err).to.be.not.exists()
-          expect(resp).to.be.equals(3)
-          hemera.close(done)
-        }
-      )
-    })
-  })
-
-  it('Should call add handler only once', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-    const spy = Sinon.spy()
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          spy()
-          const a = await {
-            result: resp.a + resp.b
-          }
-          return a
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        (err, resp) => {
-          expect(err).not.to.be.exists()
-          expect(resp.result).to.be.equals(3)
-          expect(spy.calledOnce).to.be.equals(true)
-          hemera.close(done)
-        }
-      )
-    })
-  })
-
-  it('Should be able to await in add', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          const a = await {
-            result: resp.a + resp.b
-          }
-          return a
-        }
-      )
-
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'multiply'
-        },
-        async function(resp) {
-          const a = await {
-            result: resp.a * resp.b
-          }
-          return a
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        (err, resp) => {
-          expect(err).not.to.be.exists()
-          expect(resp.result).to.be.equals(3)
-
-          hemera.act(
-            {
-              topic: 'math',
-              cmd: 'multiply',
-              a: resp.result,
-              b: 2
-            },
-            (err, resp) => {
-              expect(err).not.to.be.exists()
-              expect(resp.result).to.be.equals(6)
-
-              hemera.close(done)
-            }
-          )
-        }
-      )
-    })
-  })
-
-  it('Should be able to use none await function in add', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        function(resp, reply) {
-          reply(null, {
-            result: resp.a + resp.b
-          })
-        }
-      )
-
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'multiply'
-        },
-        function(resp, reply) {
-          reply(null, {
-            result: resp.a * resp.b
-          })
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        (err, resp) => {
-          expect(err).not.to.be.exists()
-          expect(resp.result).to.be.equals(3)
-
-          hemera.act(
-            {
-              topic: 'math',
-              cmd: 'multiply',
-              a: resp.result,
-              b: 2
-            },
-            (err, resp) => {
-              expect(err).not.to.be.exists()
-              expect(resp.result).to.be.equals(6)
-
-              hemera.close(done)
-            }
-          )
-        }
-      )
-    })
-  })
-
-  it('Should be able to await an act', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          const mult = await this.act({
-            topic: 'math',
-            cmd: 'multiply',
-            a: 1,
-            b: 2
-          })
-
-          expect(mult.data).to.be.equals({
-            result: 2
-          })
-
-          return {
-            result: resp.a + resp.b
-          }
-        }
-      )
-
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'multiply'
-        },
-        async function(resp) {
-          const a = await {
-            result: resp.a * resp.b
-          }
-          return a
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        function(err, resp) {
-          expect(err).not.to.be.exists()
-          expect(resp.result).to.be.equals(3)
-          hemera.close(done)
-        }
-      )
-    })
-  })
-
-  it('Should be able to await an act in pubsub mode', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(async () => {
-      hemera.add(
-        {
-          pubsub$: true,
-          topic: 'math',
-          cmd: 'add'
-        },
-        function(resp) {}
-      )
-
-      const result = await hemera.act({
-        pubsub$: true,
+    return hemera
+      .act({
         topic: 'math',
         cmd: 'add',
         a: 1,
         b: 2
       })
-
-      expect(result.data).to.be.not.exists()
-      expect(result.context).to.be.exists()
-
-      hemera.close(done)
-    })
-  })
-
-  it('Should be able to await inside ready callback', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(async () => {
-      hemera.add(
-        {
-          pubsub$: true,
-          topic: 'math',
-          cmd: 'add'
-        },
-        function(resp) {}
-      )
-
-      await hemera.act({
-        pubsub$: true,
-        topic: 'math',
-        cmd: 'add',
-        a: 1,
-        b: 2
-      })
-      hemera.close(done)
-    })
-  })
-
-  it('Should be able to propagate errors in add', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          await Promise.reject(new Error('test'))
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        function(err, resp) {
-          expect(err).to.be.exists()
-          expect(err.name).to.be.equals('Error')
-          expect(err.name).to.be.equals('Error')
-          hemera.close(done)
-        }
-      )
-    })
-  })
-
-  it('Should call the act handler only once per call', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-    const spy = Sinon.spy()
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          const result = await Promise.resolve({
-            result: true
-          })
-          return result
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        async function(err, resp) {
-          spy()
-          expect(err).to.be.not.exists()
-
-          setTimeout(() => {
-            expect(spy.calledOnce).to.be.equals(true)
-            hemera.close(done)
-          }, 30)
-        }
-      )
-    })
-  })
-
-  it('Should be able to chain an act', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          const result = await Promise.resolve({
-            result: true
-          })
-          return result
-        }
-      )
-
-      hemera
-        .act({
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        })
-        .then(function(out) {
-          expect(out.data).to.be.equals({
-            result: true
-          })
-          hemera.close(done)
-        })
-    })
-  })
-
-  it('Should be able to catch an error in act', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    hemera.ready(async () => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          await Promise.reject(new Error('test'))
-        }
-      )
-
-      try {
-        await hemera.act({
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        })
-      } catch (err) {
+      .catch(err => {
         expect(err).to.be.exists()
-        hemera.close(done)
-      }
-    })
+        expect(err.name).to.be.equals('Error')
+        expect(err.message).to.be.equals('test')
+        return hemera.close()
+      })
   })
 
-  it('Should be able to return result without to handle it', function(done) {
+  it('Should be able to await in end function of the middleware', async function() {
     const nats = require('nats').connect(authUrl)
 
     const hemera = new Hemera(nats)
 
-    hemera.ready(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        async function(resp) {
-          await Promise.resolve({
-            result: true
-          })
-        }
-      )
+    await hemera.ready()
 
-      hemera.act({
+    hemera
+      .add({
+        topic: 'math',
+        cmd: 'add'
+      })
+      .end(async function(req) {
+        const a = await Promise.resolve(req.a + req.b)
+        return a
+      })
+
+    const resp = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
+    })
+
+    expect(resp.data).to.be.equals(3)
+    return hemera.close()
+  })
+
+  it('Should call add handler only once', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+    const spy = Sinon.spy()
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'add'
+      },
+      async function(resp) {
+        spy()
+        const a = await {
+          result: resp.a + resp.b
+        }
+        return a
+      }
+    )
+
+    const resp = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
+    })
+
+    expect(resp.data.result).to.be.equals(3)
+    expect(spy.calledOnce).to.be.equals(true)
+    return hemera.close()
+  })
+
+  it('Should be able to await in add', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'add'
+      },
+      async function(resp) {
+        const a = await {
+          result: resp.a + resp.b
+        }
+        return a
+      }
+    )
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'multiply'
+      },
+      async function(resp) {
+        const a = await {
+          result: resp.a * resp.b
+        }
+        return a
+      }
+    )
+
+    let resp = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
+    })
+
+    expect(resp.data.result).to.be.equals(3)
+
+    resp = await hemera.act({
+      topic: 'math',
+      cmd: 'multiply',
+      a: resp.data.result,
+      b: 2
+    })
+
+    expect(resp.data.result).to.be.equals(6)
+    return hemera.close()
+  })
+
+  it('Should be able to await an act', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'add'
+      },
+      async function(resp) {
+        const mult = await this.act({
+          topic: 'math',
+          cmd: 'multiply',
+          a: 1,
+          b: 2
+        })
+
+        expect(mult.data).to.be.equals({
+          result: 2
+        })
+
+        return {
+          result: resp.a + resp.b
+        }
+      }
+    )
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'multiply'
+      },
+      async function(resp) {
+        const a = await {
+          result: resp.a * resp.b
+        }
+        return a
+      }
+    )
+
+    let resp = await hemera.act({
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
+    })
+
+    expect(resp.data.result).to.be.equals(3)
+    return hemera.close()
+  })
+
+  it('Should be able to await an act in pubsub mode', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        pubsub$: true,
+        topic: 'math',
+        cmd: 'add'
+      },
+      function(resp) {}
+    )
+
+    const result = await hemera.act({
+      pubsub$: true,
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
+    })
+
+    expect(result.data).to.be.not.exists()
+    expect(result.context).to.be.exists()
+
+    return hemera.close()
+  })
+
+  it('Should be able to await inside ready callback', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+    const spy = Sinon.spy()
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        pubsub$: true,
+        topic: 'math',
+        cmd: 'add'
+      },
+      function(resp) {
+        spy()
+      }
+    )
+
+    await hemera.act({
+      pubsub$: true,
+      topic: 'math',
+      cmd: 'add',
+      a: 1,
+      b: 2
+    })
+
+    expect(spy.calledOnce).to.be.true()
+
+    return hemera.close()
+  })
+
+  it('Should be able to propagate errors in add', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'add'
+      },
+      async function(resp) {
+        await Promise.reject(new Error('test'))
+      }
+    )
+
+    return hemera
+      .act({
         topic: 'math',
         cmd: 'add',
         a: 1,
         b: 2
       })
+      .catch(err => {
+        expect(err).to.be.exists()
+        expect(err.name).to.be.equals('Error')
+        return hemera.close()
+      })
+  })
 
-      setTimeout(() => {
-        hemera.close(done)
-      }, 50)
-    })
+  it('Should be able to chain an act', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'add'
+      },
+      async function(resp) {
+        const result = await Promise.resolve({
+          result: true
+        })
+        return result
+      }
+    )
+
+    return hemera
+      .act({
+        topic: 'math',
+        cmd: 'add',
+        a: 1,
+        b: 2
+      })
+      .then(function(out) {
+        expect(out.data).to.be.equals({
+          result: true
+        })
+        return hemera.close()
+      })
+  })
+
+  it('Should be able to catch an error in act', async function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    await hemera.ready()
+
+    hemera.add(
+      {
+        topic: 'math',
+        cmd: 'add'
+      },
+      async function(resp) {
+        await Promise.reject(new Error('test'))
+      }
+    )
+
+    try {
+      await hemera.act({
+        topic: 'math',
+        cmd: 'add',
+        a: 1,
+        b: 2
+      })
+    } catch (err) {
+      expect(err).to.be.exists()
+      hemera.close()
+    }
   })
 })

--- a/test/hemera/async-await.js
+++ b/test/hemera/async-await.js
@@ -329,7 +329,7 @@ describe('Async / Await support', function() {
             b: 2
           })
 
-          expect(mult).to.be.equals({
+          expect(mult.data).to.be.equals({
             result: 2
           })
 
@@ -383,13 +383,16 @@ describe('Async / Await support', function() {
         function(resp) {}
       )
 
-      await hemera.act({
+      const result = await hemera.act({
         pubsub$: true,
         topic: 'math',
         cmd: 'add',
         a: 1,
         b: 2
       })
+
+      expect(result.data).to.be.not.exists()
+      expect(result.context).to.be.exists()
 
       hemera.close(done)
     })
@@ -520,8 +523,8 @@ describe('Async / Await support', function() {
           a: 1,
           b: 2
         })
-        .then(function(resp) {
-          expect(resp).to.be.equals({
+        .then(function(out) {
+          expect(out.data).to.be.equals({
             result: true
           })
           hemera.close(done)

--- a/test/hemera/promise-context.spec.js
+++ b/test/hemera/promise-context.spec.js
@@ -1,0 +1,96 @@
+describe('Promise context', function() {
+  var PORT = 6242
+  var authUrl = 'nats://localhost:' + PORT
+  var server
+
+  // Start up our own nats-server
+  before(function(done) {
+    server = HemeraTestsuite.start_server(PORT, done)
+  })
+
+  // Shutdown our server after we are done
+  after(function() {
+    server.kill()
+  })
+
+  it('Should be able to act with context', function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    return hemera.ready().then(() => {
+      hemera.add(
+        {
+          topic: 'math',
+          cmd: 'add'
+        },
+        resp => {
+          return Promise.resolve(resp.a + resp.b)
+        }
+      )
+
+      return hemera
+        .act({
+          topic: 'math',
+          cmd: 'add',
+          a: 1,
+          b: 2
+        })
+        .then(out => {
+          expect(out.data).to.be.equals(3)
+          return out.context.act({
+            topic: 'math',
+            cmd: 'add',
+            a: 1,
+            b: 2
+          })
+        })
+        .then(() => hemera.close())
+    })
+  })
+
+  it('Should pass the correct context', function() {
+    const nats = require('nats').connect(authUrl)
+
+    const hemera = new Hemera(nats)
+
+    return hemera.ready().then(() => {
+      hemera.add(
+        {
+          topic: 'math',
+          cmd: 'add'
+        },
+        resp => {
+          return Promise.resolve(resp.a + resp.b)
+        }
+      )
+
+      return hemera
+        .act({
+          topic: 'math',
+          cmd: 'add',
+          a: 1,
+          b: 2,
+          context$: { a: 1 },
+          meta$: { a: 2 },
+          delegate$: { a: 3 }
+        })
+        .then(out => {
+          expect(out.data).to.be.equals(3)
+          expect(out.context.delegate$).to.be.equals({ a: 3 })
+          return out.context
+            .act({
+              topic: 'math',
+              cmd: 'add',
+              a: 1,
+              b: 2
+            })
+            .then(out => {
+              expect(out.context.context$).to.be.equals({ a: 1 })
+              expect(out.context.meta$).to.be.equals({ a: 2 })
+            })
+        })
+        .then(() => hemera.close())
+    })
+  })
+})

--- a/test/hemera/promise.spec.js
+++ b/test/hemera/promise.spec.js
@@ -197,41 +197,4 @@ describe('Promise', function() {
         })
     })
   })
-
-  it('Should call act handler only once', function(done) {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-    const spy = Sinon.spy()
-
-    hemera.ready().then(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        resp => {
-          return Promise.resolve(resp.a + resp.b)
-        }
-      )
-
-      hemera.act(
-        {
-          topic: 'math',
-          cmd: 'add',
-          a: 1,
-          b: 2
-        },
-        (err, resp) => {
-          expect(err).to.be.not.exists()
-          spy()
-          expect(resp).to.be.equals(3)
-          setTimeout(() => {
-            expect(spy.calledOnce).to.be.equals(true)
-            hemera.close(done)
-          }, 20)
-        }
-      )
-    })
-  })
 })

--- a/test/hemera/promise.spec.js
+++ b/test/hemera/promise.spec.js
@@ -75,19 +75,17 @@ describe('Promise', function() {
         }
       )
 
-      return hemera.act(
-        {
+      return hemera
+        .act({
           topic: 'math',
           cmd: 'add',
           a: 1,
           b: 2
-        },
-        (err, resp) => {
-          expect(err).to.be.not.exists()
+        })
+        .then(resp => {
           expect(resp).to.be.equals(3)
           return hemera.close()
-        }
-      )
+        })
     })
   })
 
@@ -155,20 +153,18 @@ describe('Promise', function() {
         }
       )
 
-      return hemera.act(
-        {
+      return hemera
+        .act({
           topic: 'math',
           cmd: 'add',
           a: 1,
           b: 2
-        },
-        (err, resp) => {
-          expect(err).to.be.not.exists()
+        })
+        .then(resp => {
           expect(resp).to.be.equals(3)
           expect(spy.calledOnce).to.be.equals(true)
           return hemera.close()
-        }
-      )
+        })
     })
   })
 
@@ -188,18 +184,17 @@ describe('Promise', function() {
         }
       )
 
-      return hemera.act(
-        {
+      return hemera
+        .act({
           topic: 'math',
           cmd: 'add',
           a: 1,
           b: 2
-        },
-        (err, resp) => {
+        })
+        .catch(err => {
           expect(err).to.be.exists()
           return hemera.close()
-        }
-      )
+        })
     })
   })
 

--- a/test/hemera/promise.spec.js
+++ b/test/hemera/promise.spec.js
@@ -36,8 +36,8 @@ describe('Promise', function() {
           a: 1,
           b: 2
         })
-        .then(resp => {
-          expect(resp).to.be.equals(3)
+        .then(out => {
+          expect(out.data).to.be.equals(3)
           return hemera.close()
         })
     })
@@ -82,8 +82,8 @@ describe('Promise', function() {
           a: 1,
           b: 2
         })
-        .then(resp => {
-          expect(resp).to.be.equals(3)
+        .then(out => {
+          expect(out.data).to.be.equals(3)
           return hemera.close()
         })
     })
@@ -160,8 +160,8 @@ describe('Promise', function() {
           a: 1,
           b: 2
         })
-        .then(resp => {
-          expect(resp).to.be.equals(3)
+        .then(out => {
+          expect(out.data).to.be.equals(3)
           expect(spy.calledOnce).to.be.equals(true)
           return hemera.close()
         })

--- a/test/hemera/promise.spec.js
+++ b/test/hemera/promise.spec.js
@@ -29,19 +29,17 @@ describe('Promise', function() {
         }
       )
 
-      return hemera.act(
-        {
+      return hemera
+        .act({
           topic: 'math',
           cmd: 'add',
           a: 1,
           b: 2
-        },
-        (err, resp) => {
-          expect(err).to.be.not.exists()
+        })
+        .then(resp => {
           expect(resp).to.be.equals(3)
           return hemera.close()
-        }
-      )
+        })
     })
   })
 
@@ -205,44 +203,6 @@ describe('Promise', function() {
     })
   })
 
-  it('Should be able to return a promise in act', function() {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    return hemera.ready().then(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        (resp, cb) => {
-          cb(null, {
-            result: resp.a + resp.b
-          })
-        }
-      )
-
-      return hemera
-        .act(
-          {
-            topic: 'math',
-            cmd: 'add',
-            a: 1,
-            b: 2
-          },
-          (err, resp) => {
-            expect(err).not.to.be.exists()
-            return Promise.resolve(resp.result)
-          }
-        )
-        .then(result => {
-          expect(result).to.be.equals(3)
-          return hemera.close()
-        })
-    })
-  })
-
   it('Should call act handler only once', function(done) {
     const nats = require('nats').connect(authUrl)
 
@@ -277,41 +237,6 @@ describe('Promise', function() {
           }, 20)
         }
       )
-    })
-  })
-
-  it('Should be able to return a rejected promise in act', function() {
-    const nats = require('nats').connect(authUrl)
-
-    const hemera = new Hemera(nats)
-
-    return hemera.ready().then(() => {
-      hemera.add(
-        {
-          topic: 'math',
-          cmd: 'add'
-        },
-        (resp, cb) => {
-          cb(new Error('test'))
-        }
-      )
-
-      return hemera
-        .act(
-          {
-            topic: 'math',
-            cmd: 'add',
-            a: 1,
-            b: 2
-          },
-          (err, resp) => {
-            return Promise.reject(err)
-          }
-        )
-        .catch(err => {
-          expect(err).to.be.exists()
-          return hemera.close()
-        })
     })
   })
 })

--- a/test/hemera/pub-sub.spec.js
+++ b/test/hemera/pub-sub.spec.js
@@ -94,7 +94,7 @@ describe('Publish / Subscribe', function() {
           msg: 'Hi!'
         })
         .then(a => {
-          expect(a).to.be.undefined()
+          expect(a.data).to.be.undefined()
           hemera.close(done)
         })
     })


### PR DESCRIPTION
This PR will clean up the way how promise and callback style is handled. In the past it was possible to combine both solutions like:

```js
const result = await hemera.act({
  topic: "math",
  cmd: "add"
}, async function () {
})
```
This is really hard to manage.
If you want use promises/async-await you must avoid callback style. The result of an act call is a context object. In this way, you can compose your calls with async/await and reference to a previous context.
```js
const result = await hemera.act({
  topic: "math",
  cmd: "add"
})
result.data
result.context

const result2 = await result.context.act({
  topic: "math",
  cmd: "add"
})
result2.data
result2.context
```

- [X] update docs
- [x] improve promise and async/await tests
- [x] add tests for promise context