### PR TITLE
Feature/hemera 6

### DIFF
--- a/docs/error-event.md
+++ b/docs/error-event.md
@@ -11,3 +11,15 @@ const hemera = new Hemera(nats, { logLevel: 'info' })
 hemera.on('serverResponseError', function(error) {})
 hemera.on('clientResponseError', function(error) {})
 ```
+
+### EventEmitter
+
+Hemera is an eventEmitter. If no `error` event is registered an uncaught error is thrown and the process will die but if you register an `error` handler please ensure that you handle all cases correctly. In most cases you should restart the process in oder to combe back in a clear state.
+
+This event is used for asynchronous errors:
+
+- connection is closed before hemera is closed
+
+```js
+hemera.on('error', function(error) {})
+```

--- a/docs/error-event.md
+++ b/docs/error-event.md
@@ -14,7 +14,7 @@ hemera.on('clientResponseError', function(error) {})
 
 ### EventEmitter
 
-Hemera is an eventEmitter. If no `error` event is registered an uncaught error is thrown and the process will die but if you register an `error` handler please ensure that you handle all cases correctly. In most cases you should restart the process in oder to combe back in a clear state.
+Hemera is an eventEmitter. If no `error` event is registered an uncaught error is thrown and the process will die but if you register an `error` handler please ensure that you handle all cases correctly. In most cases you should restart the process in oder to come back in a clear state.
 
 This event is used for asynchronous errors:
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -26,7 +26,7 @@ We support error-first-callback style as well as promise and async / await. Use 
 
 ## Handle a request error
 
-* Error-first-callback
+- Error-first-callback
 
   ```js
   hemera.act(
@@ -44,7 +44,7 @@ We support error-first-callback style as well as promise and async / await. Use 
   )
   ```
 
-* Promise
+- Promise
 
   ```js
   hemera
@@ -59,7 +59,7 @@ We support error-first-callback style as well as promise and async / await. Use 
     })
   ```
 
-* Async / Await
+- Async / Await
 
   ```js
   try {
@@ -77,7 +77,7 @@ We support error-first-callback style as well as promise and async / await. Use 
 
 ## Respond an error
 
-* Error-first-callback
+- Error-first-callback
 
   ```js
   hemera.add(
@@ -91,7 +91,7 @@ We support error-first-callback style as well as promise and async / await. Use 
   )
   ```
 
-* Promise
+- Promise
 
   ```js
   hemera.add(
@@ -105,7 +105,7 @@ We support error-first-callback style as well as promise and async / await. Use 
   )
   ```
 
-* Async / Await
+- Async / Await
 
   ```js
   hemera.add(
@@ -121,4 +121,4 @@ We support error-first-callback style as well as promise and async / await. Use 
 
 ## Response error
 
-A response error must be derivated from type `Error` otherwise it will be send as successful payload. An `error` message is logged when the interface has been used incorrectly.
+A response error must be derivated from type `Error` otherwise an error is logged and the client will timeout.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,7 +25,7 @@ hemera.act(
 
 ## Pretty logs
 
-Pretty logging is disabled by default you can enable it with `prettyLog` option. Before you can use it you have install the [`pino-pretty`](https://github.com/pinojs/pino-pretty) package.
+Pretty logging is disabled by default but you can enable it with `prettyLog` option. Before you can use it you have install the [`pino-pretty`](https://github.com/pinojs/pino-pretty) package.
 
 ```
 npm install --save-dev pino-pretty

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,12 +25,21 @@ hemera.act(
 
 ## Pretty logs
 
-Pretty logging is enabled by default you can disable it with `prettyLog` option.
+Pretty logging is disabled by default you can enable it with `prettyLog` option. Before you can use it you have install the [`pino-pretty`](https://github.com/pinojs/pino-pretty) package.
+
+```
+npm install --save-dev pino-pretty
+```
 
 ```js
 const hemera = new Hemera(nats, {
   logLevel: 'info',
-  prettyLog: false
+  prettyLog: true
+})
+// or
+const hemera = new Hemera(nats, {
+  logLevel: 'info',
+  prettyLog: {} // pino-pretty options
 })
 ```
 
@@ -55,12 +64,12 @@ const hemera = new Hemera(nats, {
 
 ## Log levels
 
-* info
-* warn
-* debug
-* trace
-* error
-* fatal
+- info
+- warn
+- debug
+- trace
+- error
+- fatal
 
 ## Child logger
 

--- a/packages/hemera/lib/configScheme.js
+++ b/packages/hemera/lib/configScheme.js
@@ -10,7 +10,9 @@ module.exports = Joi.object().keys({
     .default(2000),
   tag: Joi.string().default(''),
   // Enables pretty log formatter in Pino default logger
-  prettyLog: Joi.boolean().default(true),
+  prettyLog: Joi.alternatives()
+    .try(Joi.boolean(), Joi.object())
+    .default(false),
   // The name of the instance
   name: Joi.string().default(`hemera-${Os.hostname()}-${Util.randomId()}`),
   logLevel: Joi.any()
@@ -23,21 +25,7 @@ module.exports = Joi.object().keys({
     .integer()
     .default(0),
   // Custom logger
-  logger: Joi.alternatives().try(
-    Joi.object()
-      .keys({
-        info: Joi.func(),
-        error: Joi.func(),
-        debug: Joi.func(),
-        fatal: Joi.func(),
-        warn: Joi.func(),
-        trace: Joi.func(),
-        child: Joi.func()
-      })
-      .requiredKeys('info', 'error', 'debug', 'fatal', 'warn', 'trace')
-      .unknown(),
-    Joi.object().type(Stream)
-  ),
+  logger: Joi.alternatives().try(Joi.object(), Joi.object().type(Stream)),
   // Attach trace and request informations to the logs. It costs ~10% perf
   traceLog: Joi.boolean().default(false),
   // The error serialization options

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -872,6 +872,7 @@ class Hemera extends EventEmitter {
       ).causedBy(extensionError)
       self.log.error(internalError)
       self.emit('serverResponseError', extensionError)
+      self.reply.isError = true
       self.reply.send(extensionError)
       return
     }
@@ -896,6 +897,7 @@ class Hemera extends EventEmitter {
       )
       self.log.error(internalError)
       self.emit('serverResponseError', internalError)
+      self.reply.isError = true
       self.reply.send(internalError)
     }
   }
@@ -916,6 +918,7 @@ class Hemera extends EventEmitter {
       ).causedBy(extensionError)
       self.log.error(internalError)
       self.emit('serverResponseError', extensionError)
+      self.reply.isError = true
       self.reply.send(extensionError)
       return
     }
@@ -942,6 +945,7 @@ class Hemera extends EventEmitter {
       ).causedBy(err)
       self.log.error(internalError)
       self.emit('serverResponseError', err)
+      self.reply.isError = true
       self.reply.send(err)
       return
     }
@@ -955,7 +959,7 @@ class Hemera extends EventEmitter {
       result.then(
         payload => self.reply.send(payload),
         err => {
-          self._isValidError(err)
+          self.reply.isError = true
           self.reply.send(err)
         }
       )
@@ -981,26 +985,12 @@ class Hemera extends EventEmitter {
 
     return action(self.request.payload.pattern, (err, result) => {
       if (err) {
-        self._isValidError(err)
+        self.reply.isError = true
         self.reply.send(err)
         return
       }
       self.reply.send(result)
     })
-  }
-
-  /**
-   *
-   * @param {*} err
-   */
-  _isValidError(err) {
-    if (!(err instanceof Error)) {
-      this.log.error(
-        new Errors.HemeraError(
-          `Response error must be derivated from type 'Error' but got '${typeof err}'`
-        )
-      )
-    }
   }
 
   /**

--- a/packages/hemera/lib/index.js
+++ b/packages/hemera/lib/index.js
@@ -213,7 +213,7 @@ class Hemera extends EventEmitter {
   _configureLogger() {
     const loggerOpts = {
       name: this._config.name,
-      safe: true, // handle circular refs
+      prettyPrint: this._config.prettyLog,
       level: this._config.logLevel
     }
     if (this._config.logger instanceof Stream) {
@@ -221,12 +221,7 @@ class Hemera extends EventEmitter {
     } else if (this._config.logger) {
       this.log = this._config.logger
     } else {
-      const pretty = this._config.prettyLog ? Pino.pretty() : undefined
-      this.log = Pino(loggerOpts, pretty)
-      // Leads to too much listeners in tests
-      if (pretty && this._config.logLevel !== 'silent') {
-        pretty.pipe(process.stdout)
-      }
+      this.log = Pino(loggerOpts)
     }
   }
 

--- a/packages/hemera/lib/reply.js
+++ b/packages/hemera/lib/reply.js
@@ -35,6 +35,7 @@ class Reply {
     this.hemera = hemera
     this.log = logger
     this.sent = false
+    this.isError = false
   }
 
   /**
@@ -102,13 +103,23 @@ class Reply {
       return
     }
 
+    if (!(msg instanceof Error) && self.isError === true) {
+      const internalError = new Errors.HemeraError(
+        `Response error must be derivated from type 'Error' but got '${typeof msg}'`
+      )
+      self.log.error(internalError)
+      return
+    }
+
     self.sent = true
 
     // 0, null, '' can be send
     if (msg !== undefined) {
       if (msg instanceof Error) {
         self.error = msg
+        self.payload = null
       } else {
+        self.error = null
         self.payload = msg
       }
     }

--- a/packages/hemera/package.json
+++ b/packages/hemera/package.json
@@ -49,7 +49,7 @@
     "fast-safe-stringify": "2.0.x",
     "heavy": "4.0.x",
     "joi": "11.1.x",
-    "pino": "4.17.x",
+    "pino": "5.0.x",
     "super-error": "2.2.x",
     "tinysonic": "1.3.x"
   },

--- a/test/hemera/default-config.spec.js
+++ b/test/hemera/default-config.spec.js
@@ -21,7 +21,7 @@ describe('Hemera default config', function() {
     var defaultConfig = {
       timeout: 2000, // Max execution time of a request
       tag: '',
-      prettyLog: true,
+      prettyLog: false,
       name: 'test', // node name
       logLevel: 'silent', // 'fatal', 'error', 'warn', 'info', 'debug', 'trace'; also 'silent'
       childLogger: false, // Create a child logger per section / plugin. Only possible with default logger Pino.

--- a/test/hemera/error-logging.spec.js
+++ b/test/hemera/error-logging.spec.js
@@ -32,9 +32,6 @@ describe('Error logs', function() {
     })
 
     hemera.ready(() => {
-      // to prevent uncaught error
-      hemera.on('error', () => {})
-
       hemera.add(
         {
           topic: 'math',

--- a/test/hemera/error-logging.spec.js
+++ b/test/hemera/error-logging.spec.js
@@ -17,12 +17,13 @@ describe('Error logs', function() {
     server.kill()
   })
 
-  it('Should log an error when no error object was passed', function(done) {
+  it('Should log an error when no native error object was passed in server action', function(done) {
     const nats = require('nats').connect(authUrl)
     const stream = split(JSON.parse)
     const hemera = new Hemera(nats, {
       logLevel: 'error',
-      logger: stream
+      logger: stream,
+      timeout: 25
     })
     const logs = []
 
@@ -31,6 +32,9 @@ describe('Error logs', function() {
     })
 
     hemera.ready(() => {
+      // to prevent uncaught error
+      hemera.on('error', () => {})
+
       hemera.add(
         {
           topic: 'math',
@@ -47,7 +51,9 @@ describe('Error logs', function() {
           b: 2
         },
         (err, resp) => {
-          expect(err).to.be.not.exists()
+          expect(err).to.be.exists()
+          expect(err.name).to.be.equals('TimeoutError')
+          expect(resp).to.be.undefined()
           expect(logs[0].msg).to.be.equals(
             `Response error must be derivated from type 'Error' but got 'string'`
           )

--- a/test/hemera/logging.spec.js
+++ b/test/hemera/logging.spec.js
@@ -88,12 +88,12 @@ describe('Logging interface', function() {
     try {
       // eslint-disable-next-line no-new
       new Hemera(nats, {
-        logger: {}
+        logger: null
       })
     } catch (err) {
       expect(err).to.be.exists()
       expect(err.message).to.be.equals(
-        'child "logger" fails because [child "info" fails because ["info" is required], "logger" must be an instance of "Stream"]'
+        'child "logger" fails because ["logger" must be an object, "logger" must be an object]'
       )
       nats.close()
       done()


### PR DESCRIPTION
* Don't respond with success when an error is given. This is the case when the user does not reject with an error or pass no error-instance as the first argument (callback convention). The server should respond nothing but log an error.
* Upgrade to Pino 5 logger.
* Don't check custom logger instance with Joi because it produces side-effects and causes an error.